### PR TITLE
docs: formalize local GCS cache convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Verifica sources:
 npm run sources
 ```
 
-Nota: prima di `sources`, il repo sincronizza in locale i parquet necessari dentro `.evidence/gcs-cache/`. Al momento il pattern copre `ispra-ru` e `civile-flussi`: il bucket GCS resta la fonte pubblica, ma i source SQL leggono dalla cache locale per ridurre dipendenza remota durante il refresh.
+Nota: prima di `sources`, il repo sincronizza in locale i parquet necessari dentro `.evidence/gcs-cache/`. Al momento il pattern copre `ispra-ru` e `civile-flussi`: il bucket GCS resta la fonte pubblica, ma i source SQL leggono dalla cache locale per ridurre dipendenza remota durante il refresh. La convenzione del repo e' documentata in `docs/gcs-cache-convention.md`.
 
 Validazione catalogo:
 

--- a/docs/gcs-cache-convention.md
+++ b/docs/gcs-cache-convention.md
@@ -1,0 +1,70 @@
+# GCS Cache Convention
+
+Questa repo usa una convenzione locale per alcuni source Evidence che altrimenti leggerebbero parquet pubblici direttamente da GCS durante `npm run sources`.
+
+## Obiettivo
+
+Ridurre la dipendenza remota nel path `sources` senza cambiare il bucket pubblico o il layer `pages`.
+
+Questa convenzione e':
+
+- coerente con il modello Evidence `extract first, build after`
+- specifica del repo
+- non una feature nativa o una best practice ufficiale documentata di Evidence
+
+## Path canonico
+
+La cache locale vive in:
+
+- `.evidence/gcs-cache/<technical_slug>/<anno>/...`
+
+Il contenuto della cache non va versionato nel repo.
+
+## Piano di cache
+
+Il piano dei file sincronizzati vive in:
+
+- `scripts/gcs-cache-plan.json`
+
+Ogni entry dichiara:
+
+- `slug`
+- `files`
+- `remoteUrl`
+- `relativePath`
+
+Lo script di sync legge questa configurazione e popola la cache locale prima di `npm run sources`.
+
+## Refresh
+
+Per default:
+
+- se il file locale esiste e non e' vuoto, lo script usa `cache hit`
+- se manca, lo scarica da GCS
+
+Per forzare il refresh:
+
+```powershell
+$env:FORCE_GCS_SYNC=1
+npm run sources
+```
+
+## Quando usare la cache locale
+
+La cache locale va preferita quando un source:
+
+- legge parquet remoti direttamente da GCS
+- pesa in modo visibile su `npm run sources`
+- introduce fragilita' o fetch ripetuti non necessari
+
+Non tutti i dataset devono per forza usarla subito.
+
+## Regola pratica
+
+Prima di aggiungere un nuovo caso alla cache:
+
+1. verificare che il source sia davvero un collo di bottiglia o una fragilita'
+2. aggiungere i file al `gcs-cache-plan.json`
+3. aggiornare il source SQL a leggere da `.evidence/gcs-cache/...`
+4. verificare `npm run sources`
+5. verificare `npm run build`

--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -1,0 +1,36 @@
+[
+  {
+    "slug": "ispra_ru_base",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2020/ispra_ru_base_2020_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/ispra_ru_base/2020/ispra_ru_base_2020_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2021/ispra_ru_base_2021_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/ispra_ru_base/2021/ispra_ru_base_2021_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2022/ispra_ru_base_2022_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/ispra_ru_base/2022/ispra_ru_base_2022_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2023/ispra_ru_base_2023_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/ispra_ru_base/2023/ispra_ru_base_2023_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet"
+      }
+    ]
+  },
+  {
+    "slug": "civile_flussi_2014_2024",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet"
+      }
+    ]
+  }
+]

--- a/scripts/sync_gcs_cache.mjs
+++ b/scripts/sync_gcs_cache.mjs
@@ -2,28 +2,10 @@ import { createWriteStream } from 'node:fs';
 import { mkdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import cachePlan from './gcs-cache-plan.json' with { type: 'json' };
 
 const force = process.env.FORCE_GCS_SYNC === '1';
 const root = process.cwd();
-
-const cachePlan = [
-  {
-    slug: 'ispra_ru_base',
-    files: [2020, 2021, 2022, 2023, 2024].map((year) => ({
-      remoteUrl: `https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/${year}/ispra_ru_base_${year}_clean.parquet`,
-      relativePath: path.join('.evidence', 'gcs-cache', 'ispra_ru_base', String(year), `ispra_ru_base_${year}_clean.parquet`)
-    }))
-  },
-  {
-    slug: 'civile_flussi_2014_2024',
-    files: [
-      {
-        remoteUrl: 'https://storage.googleapis.com/dataciviclab-clean/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet',
-        relativePath: path.join('.evidence', 'gcs-cache', 'civile_flussi_2014_2024', '2024', 'civile_flussi_2014_2024_2024_clean.parquet')
-      }
-    ]
-  }
-];
 
 async function fileExists(filePath) {
   try {


### PR DESCRIPTION
## Sintesi

Formalizza nel repo la convenzione della cache locale GCS per i source Evidence, separando la configurazione del piano di cache dalla logica di sync.

Closes #40

## Cosa cambia

- aggiunge `docs/gcs-cache-convention.md` come riferimento corto della convenzione repo-level
- sposta il piano dei file sincronizzati in `scripts/gcs-cache-plan.json`
- lascia a `scripts/sync_gcs_cache.mjs` solo la logica di sync
- aggiorna il README per puntare alla convenzione documentata

## Perché

Dopo i P1/P2 su `ispra-ru` e `civile-flussi`, il repo aveva gia' un pattern di cache locale funzionante ma ancora implicito.

Questa PR rende espliciti:

- path canonico della cache
- regola di refresh
- criteri per aggiungere nuovi dataset
- distinzione tra convenzione del repo e feature nativa di Evidence

## Verifica

- `npm run sources`
- `npm run build`

## Rischi residui

- la convenzione e' minima, non un sistema generale di ingestion
- i source remoti residui restano da trattare a parte in `#41`
