### PR TITLE
Porta terna in cache locale nel data explorer

### DIFF
--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -32,5 +32,18 @@
         "relativePath": ".evidence/gcs-cache/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet"
       }
     ]
+  },
+  {
+    "slug": "terna_electricity_by_source",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/terna_electricity_by_source/2023/terna_electricity_by_source_2023_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/terna_electricity_by_source/2023/terna_electricity_by_source_2023_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet"
+      }
+    ]
   }
 ]

--- a/scripts/sync_gcs_cache.mjs
+++ b/scripts/sync_gcs_cache.mjs
@@ -6,7 +6,6 @@ import cachePlan from './gcs-cache-plan.json' with { type: 'json' };
 
 const force = process.env.FORCE_GCS_SYNC === '1';
 const root = process.cwd();
-
 async function fileExists(filePath) {
   try {
     const info = await stat(filePath);

--- a/scripts/sync_gcs_cache.mjs
+++ b/scripts/sync_gcs_cache.mjs
@@ -6,6 +6,7 @@ import cachePlan from './gcs-cache-plan.json' with { type: 'json' };
 
 const force = process.env.FORCE_GCS_SYNC === '1';
 const root = process.cwd();
+
 async function fileExists(filePath) {
   try {
     const info = await stat(filePath);

--- a/sources/terna/energia.sql
+++ b/sources/terna/energia.sql
@@ -7,7 +7,7 @@ SELECT
   produzione_gwh
 FROM read_parquet(
   [
-    'https://storage.googleapis.com/dataciviclab-clean/terna_electricity_by_source/2023/terna_electricity_by_source_2023_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet'
+    '.evidence/gcs-cache/terna_electricity_by_source/2023/terna_electricity_by_source_2023_clean.parquet',
+    '.evidence/gcs-cache/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet'
   ]
 )


### PR DESCRIPTION
﻿## Sintesi
- aggiunge i parquet `terna` al piano di cache locale
- aggiorna il source `terna` per leggere da `.evidence/gcs-cache` invece che da URL GCS pubblici
- valida il fix con `npm run sources`

Refs #41
