### PR TITLE
Porta dipendenti_pubblici in cache locale nel data explorer

### DIFF
--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -45,5 +45,22 @@
         "relativePath": ".evidence/gcs-cache/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet"
       }
     ]
+  },
+  {
+    "slug": "dipendenti_pubblici_2021_2023",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2021/dipendenti_pubblici_2021_2023_2021_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/dipendenti_pubblici_2021_2023/2021/dipendenti_pubblici_2021_2023_2021_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2022/dipendenti_pubblici_2021_2023_2022_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/dipendenti_pubblici_2021_2023/2022/dipendenti_pubblici_2021_2023_2022_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2023/dipendenti_pubblici_2021_2023_2023_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/dipendenti_pubblici_2021_2023/2023/dipendenti_pubblici_2021_2023_2023_clean.parquet"
+      }
+    ]
   }
 ]

--- a/sources/dipendenti_pubblici/occupazione.sql
+++ b/sources/dipendenti_pubblici/occupazione.sql
@@ -7,9 +7,9 @@ SELECT
   cessati_totali
 FROM read_parquet(
   [
-    'https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2021/dipendenti_pubblici_2021_2023_2021_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2022/dipendenti_pubblici_2021_2023_2022_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici_2021_2023/2023/dipendenti_pubblici_2021_2023_2023_clean.parquet'
+    '.evidence/gcs-cache/dipendenti_pubblici_2021_2023/2021/dipendenti_pubblici_2021_2023_2021_clean.parquet',
+    '.evidence/gcs-cache/dipendenti_pubblici_2021_2023/2022/dipendenti_pubblici_2021_2023_2022_clean.parquet',
+    '.evidence/gcs-cache/dipendenti_pubblici_2021_2023/2023/dipendenti_pubblici_2021_2023_2023_clean.parquet'
   ]
 )
 WHERE comparto IS NOT NULL


### PR DESCRIPTION
## Sintesi
- aggiunge i 3 parquet di dipendenti_pubblici al piano cache locale
- aggiorna il source occupazione a leggere da .evidence/gcs-cache
- valida la modifica con npm run sources

Rif. #41