### PR TITLE
Porta irpef_comunale in cache locale nel data explorer

### DIFF
--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -62,5 +62,30 @@
         "relativePath": ".evidence/gcs-cache/dipendenti_pubblici_2021_2023/2023/dipendenti_pubblici_2021_2023_2023_clean.parquet"
       }
     ]
+  },
+  {
+    "slug": "irpef_comunale_2019_2023",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2019/irpef_comunale_2019_2023_2019_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2019/irpef_comunale_2019_2023_2019_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2020/irpef_comunale_2019_2023_2020_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2020/irpef_comunale_2019_2023_2020_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2021/irpef_comunale_2019_2023_2021_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2021/irpef_comunale_2019_2023_2021_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2022/irpef_comunale_2019_2023_2022_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2022/irpef_comunale_2019_2023_2022_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2023/irpef_comunale_2019_2023_2023_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2023/irpef_comunale_2019_2023_2023_clean.parquet"
+      }
+    ]
   }
 ]

--- a/sources/irpef_comunale/capacita_fiscale.sql
+++ b/sources/irpef_comunale/capacita_fiscale.sql
@@ -11,11 +11,11 @@ SELECT
   addizionale_comunale_eur
 FROM read_parquet(
   [
-    'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2019/irpef_comunale_2019_2023_2019_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2020/irpef_comunale_2019_2023_2020_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2021/irpef_comunale_2019_2023_2021_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2022/irpef_comunale_2019_2023_2022_clean.parquet',
-    'https://storage.googleapis.com/dataciviclab-clean/irpef_comunale_2019_2023/2023/irpef_comunale_2019_2023_2023_clean.parquet'
+    '.evidence/gcs-cache/irpef_comunale_2019_2023/2019/irpef_comunale_2019_2023_2019_clean.parquet',
+    '.evidence/gcs-cache/irpef_comunale_2019_2023/2020/irpef_comunale_2019_2023_2020_clean.parquet',
+    '.evidence/gcs-cache/irpef_comunale_2019_2023/2021/irpef_comunale_2019_2023_2021_clean.parquet',
+    '.evidence/gcs-cache/irpef_comunale_2019_2023/2022/irpef_comunale_2019_2023_2022_clean.parquet',
+    '.evidence/gcs-cache/irpef_comunale_2019_2023/2023/irpef_comunale_2019_2023_2023_clean.parquet'
   ]
 )
 WHERE comune IS NOT NULL


### PR DESCRIPTION
## Sintesi
- aggiunge i 5 parquet di irpef_comunale al piano cache locale
- aggiorna il source capacita_fiscale a leggere da .evidence/gcs-cache
- valida la modifica con npm run sources

Rif. #41