### PR TITLE
feat: aggiungi AIFA spesa farmaceutica al Data Explorer

### DIFF
--- a/catalog/datasets.json
+++ b/catalog/datasets.json
@@ -43,5 +43,14 @@
     "status": "A",
     "years": [2019, 2020, 2021, 2022, 2023],
     "source": "MEF / Finanze"
+  },
+  {
+    "slug": "aifa-spesa-consumo",
+    "technical_slug": "aifa_spesa_consumo",
+    "name": "Spesa farmaceutica convenzionata",
+    "theme": "sanita",
+    "status": "A",
+    "years": [2018, 2019, 2020, 2021, 2022, 2023, 2024],
+    "source": "AIFA — Open Data Spesa e Consumo Farmaceutico"
   }
 ]

--- a/catalog/themes.json
+++ b/catalog/themes.json
@@ -12,7 +12,7 @@
   {
     "slug": "sanita",
     "name": "Sanità",
-    "datasets": []
+    "datasets": ["aifa-spesa-consumo"]
   },
   {
     "slug": "welfare-lavoro",

--- a/pages/dataset/aifa-spesa-consumo.md
+++ b/pages/dataset/aifa-spesa-consumo.md
@@ -30,10 +30,7 @@ ORDER BY spesa_ml_eur DESC
 ```sql top_classi_atc1
 SELECT
   descrizione_atc1,
-  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
-  ROUND(SUM(spesa_convenzionata) / NULLIF(SUM(
-    (SELECT SUM(spesa_convenzionata) FROM aifa_spesa_consumo.spesa WHERE anno = '${inputs.anno_sel.value}')
-  ), 0) * 100, 1) AS quota_pct
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur
 FROM aifa_spesa_consumo.spesa
 WHERE anno = '${inputs.anno_sel.value}'
 GROUP BY descrizione_atc1
@@ -41,19 +38,7 @@ ORDER BY spesa_ml_eur DESC
 LIMIT 10
 ```
 
-```sql regioni_disctinct
-SELECT 0 AS regione_id, 'Tutte le regioni' AS regione
-UNION ALL
-SELECT ROW_NUMBER() OVER (ORDER BY regione) AS regione_id, regione
-FROM (
-  SELECT DISTINCT regione FROM aifa_spesa_consumo.spesa
-) t
-ORDER BY regione_id
-```
-
-<Dropdown name=regione_sel data={regioni_disctinct} value=regione_id label=regione defaultValue={0} />
-
-```sql spesa_mensile_regione
+```sql spesa_mensile
 SELECT
   mese,
   regione,
@@ -61,7 +46,6 @@ SELECT
   ROUND(SUM(numero_confezioni_convenzionata) / 1e6, 2) AS confezioni_ml
 FROM aifa_spesa_consumo.spesa
 WHERE anno = '${inputs.anno_sel.value}'
-  AND (${inputs.regione_sel.value} = 0 OR regione = (SELECT regione FROM regioni_disctinct WHERE regione_id = ${inputs.regione_sel.value}))
 GROUP BY mese, regione
 ORDER BY mese, spesa_ml_eur DESC
 ```
@@ -74,15 +58,15 @@ La classifica regionale mostra dove si concentra la spesa complessiva. Il valore
 
 ## Top 10 classi terapeutiche ATC1
 
-Le classi a maggiore spesa nell'anno selezionato. Il岐 calcolo è sul totale nazionale, indipendentemente dalla regione scelta.
+Le classi a maggiore spesa nell'anno selezionato, calcolate sul totale nazionale.
 
 <BarChart data={top_classi_atc1} x=descrizione_atc1 y=spesa_ml_eur yAxisTitle="Spesa (M€)" swapXY=true />
 
 ## Andamento mensile
 
-Il grafico mostra l'evoluzione della spesa mese per mese. Il filtro regione controlla sia il trend sia la tabella di dettaglio.
+L'evoluzione della spesa mese per mese per le principali regioni.
 
-<LineChart data={spesa_mensile_regione} x=mese y=spesa_ml_eur series=regione yAxisTitle="Spesa (M€)" />
+<LineChart data={spesa_mensile} x=mese y=spesa_ml_eur series=regione yAxisTitle="Spesa (M€)" />
 
 <div class="section-note">
 I dati si riferiscono al canale della <strong>farmaceutica convenzionata</strong> (prescrizioni SSN dispensate in farmacia). Sono esclusi gli acquisti diretti e il canale tracciabilità.
@@ -90,7 +74,7 @@ I dati si riferiscono al canale della <strong>farmaceutica convenzionata</strong
 
 ## Dettaglio mensile per regione
 
-<DataTable data={spesa_mensile_regione} rows=30 search=true downloadable=true />
+<DataTable data={spesa_mensile} rows=30 search=true downloadable=true />
 
 ## Risorse e dati
 

--- a/pages/dataset/aifa-spesa-consumo.md
+++ b/pages/dataset/aifa-spesa-consumo.md
@@ -1,0 +1,98 @@
+---
+title: Spesa farmaceutica convenzionata
+description: Lettura pubblica dei dati AIFA su spesa e consumo della farmaceutica convenzionata SSN per regione e classe terapeutica.
+source: AIFA — Open Data Spesa e Consumo Farmaceutico
+last_modified: 2026-05-11
+---
+
+Questo dataset raccoglie i dati AIFA sulla spesa e il consumo della farmaceutica convenzionata SSN, disaggregati per regione, mese e classe terapeutica ATC.
+
+<div class="guide-question">Come cambia tra regioni e nel tempo la spesa farmaceutica per classi terapeutiche?</div>
+
+```sql anni
+SELECT DISTINCT CAST(anno AS INTEGER) AS anno FROM aifa_spesa_consumo.spesa ORDER BY anno DESC
+```
+
+<Dropdown name=anno_sel data={anni} value=anno>
+</Dropdown>
+
+```sql spesa_per_regione
+SELECT
+  regione,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
+  ROUND(SUM(numero_confezioni_convenzionata) / 1e6, 2) AS confezioni_ml
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+GROUP BY regione
+ORDER BY spesa_ml_eur DESC
+```
+
+```sql top_classi_atc1
+SELECT
+  descrizione_atc1,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
+  ROUND(SUM(spesa_convenzionata) / NULLIF(SUM(
+    (SELECT SUM(spesa_convenzionata) FROM aifa_spesa_consumo.spesa WHERE anno = '${inputs.anno_sel.value}')
+  ), 0) * 100, 1) AS quota_pct
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+GROUP BY descrizione_atc1
+ORDER BY spesa_ml_eur DESC
+LIMIT 10
+```
+
+```sql regioni_disctinct
+SELECT 0 AS regione_id, 'Tutte le regioni' AS regione
+UNION ALL
+SELECT ROW_NUMBER() OVER (ORDER BY regione) AS regione_id, regione
+FROM (
+  SELECT DISTINCT regione FROM aifa_spesa_consumo.spesa
+) t
+ORDER BY regione_id
+```
+
+<Dropdown name=regione_sel data={regioni_disctinct} value=regione_id label=regione defaultValue={0} />
+
+```sql spesa_mensile_regione
+SELECT
+  mese,
+  regione,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
+  ROUND(SUM(numero_confezioni_convenzionata) / 1e6, 2) AS confezioni_ml
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+  AND (${inputs.regione_sel.value} = 0 OR regione = (SELECT regione FROM regioni_disctinct WHERE regione_id = ${inputs.regione_sel.value}))
+GROUP BY mese, regione
+ORDER BY mese, spesa_ml_eur DESC
+```
+
+## Spesa farmaceutica per regione
+
+La classifica regionale mostra dove si concentra la spesa complessiva. Il valore è in milioni di euro.
+
+<BarChart data={spesa_per_regione} x=regione y=spesa_ml_eur yAxisTitle="Spesa (M€)" swapXY=true />
+
+## Top 10 classi terapeutiche ATC1
+
+Le classi a maggiore spesa nell'anno selezionato. Il岐 calcolo è sul totale nazionale, indipendentemente dalla regione scelta.
+
+<BarChart data={top_classi_atc1} x=descrizione_atc1 y=spesa_ml_eur yAxisTitle="Spesa (M€)" swapXY=true />
+
+## Andamento mensile
+
+Il grafico mostra l'evoluzione della spesa mese per mese. Il filtro regione controlla sia il trend sia la tabella di dettaglio.
+
+<LineChart data={spesa_mensile_regione} x=mese y=spesa_ml_eur series=regione yAxisTitle="Spesa (M€)" />
+
+<div class="section-note">
+I dati si riferiscono al canale della <strong>farmaceutica convenzionata</strong> (prescrizioni SSN dispensate in farmacia). Sono esclusi gli acquisti diretti e il canale tracciabilità.
+</div>
+
+## Dettaglio mensile per regione
+
+<DataTable data={spesa_mensile_regione} rows=30 search=true downloadable=true />
+
+## Risorse e dati
+
+- [Scarica il clean parquet 2024](https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet)
+- [Fonte originale: AIFA — Open Data Spesa e Consumo Farmaceutico](https://www.aifa.gov.it/documents/20142/847578/dati2024_04.12.2025.csv)

--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -87,5 +87,38 @@
         "relativePath": ".evidence/gcs-cache/irpef_comunale_2019_2023/2023/irpef_comunale_2019_2023_2023_clean.parquet"
       }
     ]
+  },
+  {
+    "slug": "aifa_spesa_consumo",
+    "files": [
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2018/aifa_spesa_consumo_2018_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2018/aifa_spesa_consumo_2018_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2019/aifa_spesa_consumo_2019_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2019/aifa_spesa_consumo_2019_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2020/aifa_spesa_consumo_2020_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2020/aifa_spesa_consumo_2020_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2021/aifa_spesa_consumo_2021_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2021/aifa_spesa_consumo_2021_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2022/aifa_spesa_consumo_2022_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2022/aifa_spesa_consumo_2022_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2023/aifa_spesa_consumo_2023_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2023/aifa_spesa_consumo_2023_clean.parquet"
+      },
+      {
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet"
+      }
+    ]
   }
 ]

--- a/sources/aifa_spesa_consumo/connection.yaml
+++ b/sources/aifa_spesa_consumo/connection.yaml
@@ -1,0 +1,4 @@
+name: aifa_spesa_consumo
+type: duckdb
+options:
+  filename: ':memory:'

--- a/sources/aifa_spesa_consumo/spesa.sql
+++ b/sources/aifa_spesa_consumo/spesa.sql
@@ -1,0 +1,139 @@
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2018/aifa_spesa_consumo_2018_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2019/aifa_spesa_consumo_2019_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2020/aifa_spesa_consumo_2020_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2021/aifa_spesa_consumo_2021_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2022/aifa_spesa_consumo_2022_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2023/aifa_spesa_consumo_2023_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('.evidence/gcs-cache/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet')


### PR DESCRIPTION
## Summary
- Aggiunge il dataset **AIFA Spesa Farmaceutica Convenzionata** al Data Explorer
- Tema: **sanità** (primo dataset in questo tema)
- 7 anni di dati (2018–2024), parquet clean già pubblicati su GCS
- 3 blocchi: spesa per regione, top 10 classi ATC1, trend mensile
- GCS cache plan aggiornato con i 7 parquet
- pipeline_signals.json: `stage: published`

## Changed files
- `catalog/datasets.json` — entry per aifa-spesa-consumo
- `catalog/themes.json` — tema sanità aggiornato (datasets: [aifa-spesa-consumo])
- `scripts/gcs-cache-plan.json` — 7 file per aifa_spesa_consumo
- `sources/aifa_spesa_consumo/` — connection.yaml + spesa.sql
- `pages/dataset/aifa-spesa-consumo.md` — pagina dataset

## Note
- Il source carica ~1.2M righe (565 MB uncompressed) — accettabile per v0, ottimizzabile successivamente con loading on-demand per anno
- Dipendenze dependabot (#65 tailwindcss v4, #66 vite-plugin-svelte v7) chiuse — non compatibili con l'ecosistema Evidence attuale

## Checklist
- [x] GCS parquet 2024 accessibile (HTTP 200)
- [x] npm run sources → completato
- [x] Pagina verificata localmente (npm run dev)
- [x] Query SQL funzionanti (Barchart spesa regioni, Barchart top ATC1, LineChart trend mensile)
- [x] pipeline_signals.json aggiornato (stage: published)