### PR TITLE
fix(civile-flussi): aggiorna path parquet a /2025/ dopo passaggio DI

### DIFF
--- a/catalog/datasets.json
+++ b/catalog/datasets.json
@@ -10,11 +10,11 @@
   },
   {
     "slug": "civile-flussi",
-    "technical_slug": "civile_flussi_2014_2024",
+    "technical_slug": "civile_flussi",
     "name": "Flussi della giustizia civile",
     "theme": "giustizia",
     "status": "A",
-    "years": [2024],
+    "years": [2025],
     "source": "Ministero della Giustizia"
   },
   {

--- a/pages/dataset/civile-flussi.md
+++ b/pages/dataset/civile-flussi.md
@@ -83,5 +83,5 @@ Le <strong>Procedure concorsuali (pre-riforma)</strong> possono mostrare nuovi a
 
 ## Risorse e dati
 
-- [Scarica il clean parquet 2024](https://storage.googleapis.com/dataciviclab-clean/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet)
+- [Scarica il clean parquet 2025](https://storage.googleapis.com/dataciviclab-clean/civile_flussi/2025/civile_flussi_2025_clean.parquet)
 - [Fonte originale: Ministero della Giustizia — statistiche civili](https://datiestatistiche.giustizia.it)

--- a/scripts/gcs-cache-plan.json
+++ b/scripts/gcs-cache-plan.json
@@ -25,11 +25,11 @@
     ]
   },
   {
-    "slug": "civile_flussi_2014_2024",
+    "slug": "civile_flussi",
     "files": [
       {
-        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet",
-        "relativePath": ".evidence/gcs-cache/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet"
+        "remoteUrl": "https://storage.googleapis.com/dataciviclab-clean/civile_flussi/2025/civile_flussi_2025_clean.parquet",
+        "relativePath": ".evidence/gcs-cache/civile_flussi/2025/civile_flussi_2025_clean.parquet"
       }
     ]
   },

--- a/sources/civile_flussi/flussi.sql
+++ b/sources/civile_flussi/flussi.sql
@@ -10,5 +10,5 @@ SELECT
   definiti_totale,
   pendenti_finali
 FROM read_parquet(
-  '.evidence/gcs-cache/civile_flussi_2014_2024/2024/civile_flussi_2014_2024_2024_clean.parquet'
+  '.evidence/gcs-cache/civile_flussi/2025/civile_flussi_2025_clean.parquet'
 )


### PR DESCRIPTION
## Summary
- Aggiorna i path del dataset **civile-flussi** da `/2024/` a `/2025/`
- Il candidate è stato promosso in DI con slug `civile_flussi` e year 2025
- Tutti i riferimenti (catalog, source SQL, gcs-cache-plan, link pagina) puntano ora al nuovo path

## Changed files
- `catalog/datasets.json` — `technical_slug: civile_flussi_2014_2024` → `civile_flussi`, `years: [2025]`
- `scripts/gcs-cache-plan.json` — slug e path aggiornati
- `sources/civile_flussi/flussi.sql` — read_parquet path aggiornato
- `pages/dataset/civile-flussi.md` — link parquet aggiornato

## Checklist
- [x] GCS verify: `gs://dataciviclab-clean/civile_flussi/2025/` esiste (908 KB)
- [x] gcs-cache-plan aggiornato
- [x] Source SQL aggiornato
- [x] Catalog aggiornato

## Riferimenti
- dataciviclab/dataset-incubator#165
- dataciviclab/data-explorer#61