### PR TITLE
feat(aifa-spesa-consumo): aggiungi AIFA spesa farmaceutica al Data Explorer

### DIFF
--- a/catalog/themes.json
+++ b/catalog/themes.json
@@ -12,7 +12,7 @@
   {
     "slug": "sanita",
     "name": "Sanità",
-    "datasets": []
+    "datasets": ["aifa_spesa_consumo"]
   },
   {
     "slug": "welfare-lavoro",

--- a/pages/dataset/aifa_spesa_consumo.md
+++ b/pages/dataset/aifa_spesa_consumo.md
@@ -1,0 +1,72 @@
+---
+title: Spesa farmaceutica convenzionata
+description: Lettura pubblica dei dati AIFA su spesa e consumo della farmaceutica convenzionata SSN per regione e classe terapeutica.
+source: AIFA — Open Data Spesa e Consumo Farmaceutico
+last_modified: 2026-05-11
+---
+
+Questo dataset raccoglie i dati AIFA sulla spesa e il consumo della farmaceutica convenzionata SSN, disaggregati per regione, mese e classe terapeutica ATC.
+
+<div class="guide-question">Come cambia tra regioni e nel tempo la spesa farmaceutica per classi terapeutiche?</div>
+
+```sql anni
+SELECT DISTINCT CAST(anno AS INTEGER) AS anno FROM aifa_spesa_consumo.spesa ORDER BY anno DESC
+```
+
+<Dropdown name=anno_sel data={anni} value=anno>
+</Dropdown>
+
+```sql spesa_per_regione
+SELECT
+  regione,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
+  ROUND(SUM(numero_confezioni_convenzionata) / 1e6, 2) AS confezioni_ml
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+GROUP BY regione
+ORDER BY spesa_ml_eur DESC
+```
+
+```sql top_classi_atc1
+SELECT
+  descrizione_atc1,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+GROUP BY descrizione_atc1
+ORDER BY spesa_ml_eur DESC
+LIMIT 10
+```
+
+```sql spesa_mensile
+SELECT
+  mese,
+  regione,
+  ROUND(SUM(spesa_convenzionata) / 1e6, 2) AS spesa_ml_eur,
+  ROUND(SUM(numero_confezioni_convenzionata) / 1e6, 2) AS confezioni_ml
+FROM aifa_spesa_consumo.spesa
+WHERE anno = '${inputs.anno_sel.value}'
+GROUP BY mese, regione
+ORDER BY mese, spesa_ml_eur DESC
+```
+
+## Spesa farmaceutica per regione
+
+<BarChart data={spesa_per_regione} x=regione y=spesa_ml_eur yAxisTitle="Spesa (M euro)" swapXY=true />
+
+## Top 10 classi terapeutiche ATC1
+
+<BarChart data={top_classi_atc1} x=descrizione_atc1 y=spesa_ml_eur yAxisTitle="Spesa (M euro)" swapXY=true />
+
+## Andamento mensile
+
+<LineChart data={spesa_mensile} x=mese y=spesa_ml_eur series=regione yAxisTitle="Spesa (M euro)" />
+
+## Dettaglio mensile per regione
+
+<DataTable data={spesa_mensile} rows=30 search=true downloadable=true />
+
+## Risorse e dati
+
+- [Scarica il clean parquet 2024](https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet)
+- [Fonte originale: AIFA](https://www.aifa.gov.it)

--- a/pages/index.md
+++ b/pages/index.md
@@ -13,6 +13,7 @@ I dati vengono letti dai clean parquet pubblici del Lab e trasformati in pagine 
 
 - [Territorio e ambiente](/temi/territorio-ambiente)
 - [Finanza pubblica](/temi/finanza-pubblica)
+- [Sanita](/temi/sanita)
 - [Giustizia](/temi/giustizia)
 - [Welfare e lavoro](/temi/welfare-lavoro)
 
@@ -23,9 +24,10 @@ I dati vengono letti dai clean parquet pubblici del Lab e trasformati in pagine 
 - [Mix elettrico per regione](/dataset/terna_capacita_rinnovabile)
 - [Dipendenti pubblici per comparto](/dataset/dipendenti_pubblici)
 - [IRPEF comunale](/dataset/irpef_comunale)
+- [Spesa farmaceutica convenzionata](/dataset/aifa_spesa_consumo)
 
 ## Cosa c'e' nel v0
 
-- `5` dataset pubblici gia' leggibili
-- `4` temi attivi
+- `6` dataset pubblici gia' leggibili
+- `5` temi attivi
 - dati sorgente disponibili come clean parquet pubblici del Lab

--- a/pages/temi/sanita.md
+++ b/pages/temi/sanita.md
@@ -5,6 +5,11 @@ description: Dataset e domande civiche sulla sanità nel Data Explorer del Lab.
 
 Questo tema raccoglie dataset che aiutano a leggere la spesa sanitaria e i consumi farmaceutici con un taglio territoriale.
 
+## Domande chiave
+
+- Come cambia tra regioni e nel tempo la spesa farmaceutica per classi terapeutiche?
+- Quali sono le categorie terapeutiche che pesano di più sulla spesa convenzionata?
+
 ## Dataset collegati
 
 - [Spesa farmaceutica convenzionata](/dataset/aifa_spesa_consumo)

--- a/pages/temi/sanita.md
+++ b/pages/temi/sanita.md
@@ -1,0 +1,10 @@
+---
+title: Sanità
+description: Dataset e domande civiche sulla sanità nel Data Explorer del Lab.
+---
+
+Questo tema raccoglie dataset che aiutano a leggere la spesa sanitaria e i consumi farmaceutici con un taglio territoriale.
+
+## Dataset collegati
+
+- [Spesa farmaceutica convenzionata](/dataset/aifa_spesa_consumo)

--- a/sources/aifa_spesa_consumo/connection.yaml
+++ b/sources/aifa_spesa_consumo/connection.yaml
@@ -1,0 +1,4 @@
+name: aifa_spesa_consumo
+type: duckdb
+options:
+  filename: ':memory:'

--- a/sources/aifa_spesa_consumo/spesa.sql
+++ b/sources/aifa_spesa_consumo/spesa.sql
@@ -1,0 +1,139 @@
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2018/aifa_spesa_consumo_2018_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2019/aifa_spesa_consumo_2019_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2020/aifa_spesa_consumo_2020_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2021/aifa_spesa_consumo_2021_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2022/aifa_spesa_consumo_2022_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2023/aifa_spesa_consumo_2023_clean.parquet')
+UNION ALL
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  CAST(mese AS INTEGER) AS mese,
+  codreg,
+  regione,
+  classe,
+  atc1,
+  descrizione_atc1,
+  atc2,
+  descrizione_atc2,
+  atc3,
+  descrizione_atc3,
+  atc4,
+  descrizione_atc4,
+  numero_confezioni_traccia,
+  spesa_flusso_tracciabilita,
+  numero_confezioni_convenzionata,
+  spesa_convenzionata
+FROM read_parquet('https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet')


### PR DESCRIPTION
## Cosa cambia

Aggiunge il dataset **AIFA Spesa Farmaceutica Convenzionata** al Data Explorer.

- Tema: **sanità** — primo dataset in questo tema
- 7 anni di dati (2018–2024), parquet clean gia' pubblicati su GCS
- 3 blocchi: spesa per regione, top 10 classi ATC1, trend mensile
- Source SQL con GCS diretto (nessuna cache locale)

## File modificati

| File | Azione |
|---|---|
| `catalog/themes.json` | tema sanità: da vuoto a `[aifa_spesa_consumo]` |
| `pages/temi/sanita.md` | NUOVA pagina tema (obbligatoria per validator) |
| `sources/aifa_spesa_consumo/connection.yaml` | NUOVO |
| `sources/aifa_spesa_consumo/spesa.sql` | NUOVO (7 anni, GCS diretto) |
| `pages/dataset/aifa_spesa_consumo.md` | NUOVA (3 query curate) |

## Differenze con PR #67

Questa PR sostituisce la #67 (chiusa). Rispetto a quella:

- Nessun `catalog/datasets.json` (generato automaticamente da DI)
- Nessun `scripts/gcs-cache-plan.json` (non esiste più)
- Source SQL legge da GCS diretto, non da cache locale
- Slug allineato a DI: `aifa_spesa_consumo`

## Checklist

- [x] GCS parquet accessibile (verificato)
- [x] `npm run generate:catalog` (23 dataset)
- [x] `npm run validate:catalog` passato
- [x] Slug tema sanità allineato a DI
