### PR TITLE
refactor: allinea a stage (da status) per schema DI catalog

### DIFF
--- a/scripts/generate_catalog.mjs
+++ b/scripts/generate_catalog.mjs
@@ -31,7 +31,7 @@ function generateCatalogEntry(diEntry, themeSlug) {
     name: diEntry.name,
     description: diEntry.description || '',
     theme: themeSlug || null,
-    status: diEntry.status || 'candidate',
+    stage: diEntry.stage || 'incubating',
     years: years,
     source: diEntry.source || '',
     di_slug: diEntry.slug,

--- a/scripts/validate_catalog.mjs
+++ b/scripts/validate_catalog.mjs
@@ -2,7 +2,7 @@ import { readFile, access } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
-const VALID_STATUSES = new Set(["candidate", "clean_ready", "public_catalog_ready", "deprecated"]);
+const VALID_STATUSES = new Set(["incubating", "published", "deprecated"]);
 
 async function fileExists(relativePath) {
   try {
@@ -67,8 +67,8 @@ async function main() {
     datasetSlugs.add(ds.slug);
     datasetBySlug.set(ds.slug, ds);
 
-    if (ds.status && !VALID_STATUSES.has(ds.status)) {
-      errors.push(prefix + ".status must be one of [" + Array.from(VALID_STATUSES).join(", ") + "] - got: " + ds.status);
+    if (ds.stage && !VALID_STATUSES.has(ds.stage)) {
+      errors.push(prefix + ".stage must be one of [" + Array.from(VALID_STATUSES).join(", ") + "] - got: " + ds.stage);
     }
 
     if (Array.isArray(ds.years)) {
@@ -95,10 +95,10 @@ async function main() {
   }
 
   for (const ds of datasetBySlug.values()) {
-    if (ds.status === "public_catalog_ready") {
+    if (ds.stage === "published") {
       const pagePath = "pages/dataset/" + ds.slug + ".md";
       if (!(await fileExists(pagePath))) {
-        errors.push("dataset " + ds.slug + " has status " + ds.status + " but page " + pagePath + " does not exist");
+        errors.push("dataset " + ds.slug + " has stage " + ds.stage + " but page " + pagePath + " does not exist");
       }
     }
   }


### PR DESCRIPTION
## Cosa cambia

Allinea data-explorer al nuovo schema del catalogo DI (PR #285):
- `generate_catalog.mjs`: legge `stage` dal catalogo DI (default: `incubating`)
- `validate_catalog.mjs`: valida `stage` invece di `status` (`incubating` / `published` / `deprecated`)
- Compatibile con vecchio formato — se `stage` manca, fallback a `incubating`

Riferimento: PR dataset-incubator #285