### PR TITLE
feat: source_id nel catalogo generato (da DI catalog)

### DIFF
--- a/scripts/generate_catalog.mjs
+++ b/scripts/generate_catalog.mjs
@@ -34,6 +34,7 @@ function generateCatalogEntry(diEntry, themeSlug) {
     stage: diEntry.stage || 'incubating',
     years: years,
     source: diEntry.source || '',
+    source_id: diEntry.source_id || null,
     di_slug: diEntry.slug,
     columns: columns,
   };


### PR DESCRIPTION
## Cosa cambia

- `generate_catalog.mjs`: passa `source_id` da DI catalog al catalogo DE

### Perché

Consente alle pagine DE di linkare dataset → fonte SO.
