### PR TITLE
fix(inps-pensioni): DataTable trend, commento multi-anno, homepage aggiornata

### DIFF
--- a/catalog/themes.json
+++ b/catalog/themes.json
@@ -17,7 +17,7 @@
   {
     "slug": "welfare-lavoro",
     "name": "Welfare e lavoro",
-    "datasets": ["dipendenti_pubblici"]
+    "datasets": ["dipendenti_pubblici", "inps_pensioni_trimestrale"]
   },
   {
     "slug": "giustizia",

--- a/pages/dataset/inps_pensioni_trimestrale.md
+++ b/pages/dataset/inps_pensioni_trimestrale.md
@@ -1,0 +1,70 @@
+---
+title: Pensioni INPS
+description: Lettura pubblica delle pensioni INPS per gestione, regione, classe d'età e importo — 2020-2024.
+source: INPS Open Data
+last_modified: 2026-05-14
+---
+
+Questo dataset raccoglie il numero di pensioni INPS per gestione previdenziale, regione, sesso, classe d'età e classe di importo, con cadenza trimestrale dal 2020 al 2024.
+
+<div class="guide-question">Come sono distribuite le pensioni INPS tra gestioni, aree geografiche e categorie?</div>
+
+```sql anni
+SELECT DISTINCT CAST(anno AS INTEGER) AS anno FROM inps_pensioni_trimestrale.pensioni ORDER BY anno DESC
+```
+
+<Dropdown name=anno_sel data={anni} value=anno>
+</Dropdown>
+
+```sql distribuzione_gestione
+SELECT
+  gestione,
+  ROUND(SUM(numero_pensioni) / 1e6, 2) AS pensioni_milioni
+FROM inps_pensioni_trimestrale.pensioni
+WHERE CAST(anno AS INTEGER) = ${inputs.anno_sel.value}
+GROUP BY gestione
+ORDER BY pensioni_milioni DESC
+```
+
+```sql distribuzione_area
+SELECT
+  area_geografica,
+  sesso,
+  ROUND(SUM(numero_pensioni) / 1e6, 2) AS pensioni_milioni
+FROM inps_pensioni_trimestrale.pensioni
+WHERE CAST(anno AS INTEGER) = ${inputs.anno_sel.value}
+GROUP BY area_geografica, sesso
+ORDER BY area_geografica, sesso
+```
+
+```sql trend_pensioni
+SELECT
+  CAST(anno AS INTEGER) AS anno,
+  ROUND(SUM(numero_pensioni) / 1e6, 2) AS pensioni_milioni
+FROM inps_pensioni_trimestrale.pensioni
+GROUP BY anno
+ORDER BY anno
+```
+
+## Pensioni per gestione
+
+<BarChart data={distribuzione_gestione} x=gestione y=pensioni_milioni yAxisTitle="Pensioni (milioni)" swapXY=true />
+
+La gestione **FPLD** (Fondo Pensioni Lavoratori Dipendenti) è la componente prevalente, seguita dai Dipendenti Pubblici, Artigiani e Commercianti.
+
+## Distribuzione per area geografica e sesso
+
+<BarChart data={distribuzione_area} x=area_geografica y=pensioni_milioni series=sesso yAxisTitle="Pensioni (milioni)" />
+
+## Andamento annuale
+
+<LineChart data={trend_pensioni} x=anno y=pensioni_milioni yAxisTitle="Pensioni (milioni)" />
+
+## Dettaglio
+
+<DataTable data={distribuzione_gestione} rows=20 search=true downloadable=true />
+
+## Risorse e dati
+
+- [Scarica il clean parquet](https://storage.googleapis.com/dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet)
+- [Fonte originale: INPS](https://www.inps.it)

--- a/pages/dataset/inps_pensioni_trimestrale.md
+++ b/pages/dataset/inps_pensioni_trimestrale.md
@@ -62,7 +62,7 @@ La gestione **FPLD** (Fondo Pensioni Lavoratori Dipendenti) è la componente pre
 
 ## Dettaglio
 
-<DataTable data={distribuzione_gestione} rows=20 search=true downloadable=true />
+<DataTable data={trend_pensioni} rows=20 search=true downloadable=true />
 
 ## Risorse e dati
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -25,9 +25,11 @@ I dati vengono letti dai clean parquet pubblici del Lab e trasformati in pagine 
 - [Dipendenti pubblici per comparto](/dataset/dipendenti_pubblici)
 - [IRPEF comunale](/dataset/irpef_comunale)
 - [Spesa farmaceutica convenzionata](/dataset/aifa_spesa_consumo)
+- [Entrate dello Stato](/dataset/bdap_entrate_stato)
+- [Pensioni INPS](/dataset/inps_pensioni_trimestrale)
 
 ## Cosa c'e' nel v0
 
-- `6` dataset pubblici gia' leggibili
+- `8` dataset pubblici gia' leggibili
 - `5` temi attivi
 - dati sorgente disponibili come clean parquet pubblici del Lab

--- a/sources/inps_pensioni_trimestrale/connection.yaml
+++ b/sources/inps_pensioni_trimestrale/connection.yaml
@@ -1,0 +1,4 @@
+name: inps_pensioni_trimestrale
+type: duckdb
+options:
+  filename: ':memory:'

--- a/sources/inps_pensioni_trimestrale/pensioni.sql
+++ b/sources/inps_pensioni_trimestrale/pensioni.sql
@@ -1,3 +1,5 @@
+-- Il parquet 2024 contiene l'intero storico 2020-2024 (17 trimestri).
+-- Se in futuro il dataset viene splittato per anno, aggiornare il path.
 SELECT
   CAST(anno AS VARCHAR) AS anno,
   trimestre,

--- a/sources/inps_pensioni_trimestrale/pensioni.sql
+++ b/sources/inps_pensioni_trimestrale/pensioni.sql
@@ -1,0 +1,15 @@
+SELECT
+  CAST(anno AS VARCHAR) AS anno,
+  trimestre,
+  sesso,
+  classe_eta,
+  classe_importo,
+  area_geografica,
+  gestione,
+  tipo_gestione,
+  categoria,
+  regione,
+  numero_pensioni
+FROM read_parquet(
+  'https://storage.googleapis.com/dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet'
+)


### PR DESCRIPTION
Closes #82 
## Review findings applicati

### Modifiche

| File | Cosa |
|---|---|
| `pages/dataset/inps_pensioni_trimestrale.md` | DataTable ora mostra `trend_pensioni` invece di duplicare il grafico `distribuzione_gestione` |
| `sources/inps_pensioni_trimestrale/pensioni.sql` | Aggiunto commento: il parquet 2024 contiene tutto lo storico 2020-2024 |
| `pages/index.md` | Aggiunti `bdap_entrate_stato` (mancante dal PR #80) e `inps_pensioni_trimestrale`; conteggio portato da 6 a 8 dataset |

### Review gate

- [x] Catalogo generato e validato (`generate:catalog` + `validate:catalog` OK)
- [x] Build Evidence completata senza errori
- [x] Branch verificato e pushato

### Note

- La pagina pensioni non ha `discussion_url` — non esiste ancora una discussion pubblica su `dataciviclab/dataciviclab` per questo dataset. Da valutare se crearne una.
- L'homepage include anche `bdap_entrate_stato` che era stato saltato nel PR #80.