### PR TITLE
fix(validate): published senza pagina è warning, non errore fatale

### DIFF
--- a/scripts/validate_catalog.mjs
+++ b/scripts/validate_catalog.mjs
@@ -94,11 +94,26 @@ async function main() {
     }
   }
 
+  const featuredDatasetSlugs = new Set();
+  for (const theme of themeBySlug.values()) {
+    if (Array.isArray(theme.datasets)) {
+      for (const slug of theme.datasets) {
+        if (isNonEmptyString(slug)) featuredDatasetSlugs.add(slug);
+      }
+    }
+  }
+
   for (const ds of datasetBySlug.values()) {
     if (ds.stage === "published") {
       const pagePath = "pages/dataset/" + ds.slug + ".md";
       if (!(await fileExists(pagePath))) {
-        errors.push("dataset " + ds.slug + " has stage " + ds.stage + " but page " + pagePath + " does not exist");
+        const isFeatured = featuredDatasetSlugs.has(ds.slug);
+        const message = "dataset " + ds.slug + " has stage published but page " + pagePath + " does not exist";
+        if (isFeatured) {
+          errors.push(message + " — dataset is featured in a theme, page is required");
+        } else {
+          console.warn("[warn] " + message + " — skipping, create the page to expose it");
+        }
       }
     }
   }


### PR DESCRIPTION
## Problema

Il deploy su main fallisce se un dataset è `published` in DI ma non ha ancora una pagina `pages/dataset/<slug>.md` in data-explorer. Succede quando due dataset vengono promossi in DI indipendentemente dal PR mergiato.

Il validator blocca il deploy con errore fatale — ma il problema non è del commit che lo innesca, è un disallineamento temporaneo tra cataloghi.

## Fix

`published` senza pagina → **`console.warn`**, non `errors.push`. Il deploy prosegue, il warning resta nei log CI per chi deve creare la pagina.

## Impatto

- Il deploy non si rompe più per dataset non toccati dal commit
- La segnalazione resta visibile nei log
- Chi deve creare la pagina lo sa dai log
