### PR TITLE
Pagine tematiche (territorio, finanza, sanità, welfare, giustizia)

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -2,4 +2,31 @@ export default {
   root: "src",
   output: "dist/observable",
   title: "DataCivicLab Explorer",
+  pages: [
+    {
+      name: "Dataset",
+      collapsible: false,
+      pages: [
+        { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
+        { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
+        { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },
+        { name: "Dipendenti pubblici", path: "/dataset/dipendenti-pubblici" },
+        { name: "Capacità rinnovabile", path: "/dataset/capacita-rinnovabile" },
+        { name: "Spesa farmaceutica", path: "/dataset/spesa-farmaceutica" },
+        { name: "Entrate dello Stato", path: "/dataset/entrate-stato" },
+        { name: "Pensioni INPS", path: "/dataset/pensioni-inps" },
+      ],
+    },
+    {
+      name: "Temi",
+      collapsible: false,
+      pages: [
+        { name: "Territorio e ambiente", path: "/temi/territorio-ambiente" },
+        { name: "Finanza pubblica", path: "/temi/finanza-pubblica" },
+        { name: "Sanità", path: "/temi/sanita" },
+        { name: "Welfare e lavoro", path: "/temi/welfare-lavoro" },
+        { name: "Giustizia", path: "/temi/giustizia" },
+      ],
+    },
+  ],
 };

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Data loader: temi editoriali. Mappa slug tema → slug dataset."""
+import json, sys
+
+themes = [
+    {
+        "slug": "territorio-ambiente",
+        "name": "Territorio e ambiente",
+        "description": "Trasformazioni territoriali, ambiente, energia e rifiuti",
+        "datasets": ["rifiuti-urbani", "capacita-rinnovabile"],
+        "questions": ["Come varia la raccolta differenziata tra territori?", "Come cambia il mix elettrico regionale tra fonti fossili e rinnovabili?"],
+    },
+    {
+        "slug": "finanza-pubblica",
+        "name": "Finanza pubblica",
+        "description": "Entrate dello Stato, capacità fiscale e tributi locali",
+        "datasets": ["irpef-comunale", "entrate-stato"],
+        "questions": ["Come si distribuisce la capacità fiscale tra regioni?", "Quali sono le principali voci di entrata dello Stato?"],
+    },
+    {
+        "slug": "sanita",
+        "name": "Sanità",
+        "description": "Spesa farmaceutica, consumi sanitari e prevenzione",
+        "datasets": ["spesa-farmaceutica"],
+        "questions": ["Come cambia tra regioni la spesa farmaceutica per classi terapeutiche?"],
+    },
+    {
+        "slug": "welfare-lavoro",
+        "name": "Welfare e lavoro",
+        "description": "Pubblico impiego, pensioni e previdenza",
+        "datasets": ["dipendenti-pubblici", "pensioni-inps"],
+        "questions": ["La crescita del pubblico impiego è diffusa o concentrata in pochi comparti?", "Come sono distribuite le pensioni tra gestioni previdenziali?"],
+    },
+    {
+        "slug": "giustizia",
+        "name": "Giustizia",
+        "description": "Flussi civili, tempi e carichi dei tribunali",
+        "datasets": ["flussi-giustizia-civile"],
+        "questions": ["Come si distribuisce il carico civile tra i distretti italiani?"],
+    },
+]
+
+json.dump(themes, sys.stdout, ensure_ascii=False)

--- a/src/index.md
+++ b/src/index.md
@@ -9,26 +9,55 @@ Catalogo pubblico dei dataset civici. I dati sono puliti, documentati e disponib
 
 ```js
 const catalog = await FileAttachment("data/catalog.json").json();
+const themes = await FileAttachment("data/themes.json").json();
 ```
 
 <div class="grid grid-cols-3">
   <div class="card"><h3>Totale</h3><span class="big">${catalog.total}</span></div>
   <div class="card"><h3>Pubblicati</h3><span class="big">${catalog.published}</span></div>
-  <div class="card"><h3>In incubazione</h3><span class="big">${catalog.incubating}</span></div>
+  <div class="card"><h3>Temi</h3><span class="big">${themes.length}</span></div>
 </div>
 
-## Pagine curate
+## Temi
 
-- [IRPEF comunale](/dataset/irpef-comunale) — capacità fiscale per comune e regione
-- [Rifiuti urbani](/dataset/rifiuti-urbani) — produzione e raccolta differenziata per comune e regione
-- [Flussi giustizia civile](/dataset/flussi-giustizia-civile) — sopravvenuti, definiti e pendenti per distretto
-- [Dipendenti pubblici](/dataset/dipendenti-pubblici) — pubblico impiego per comparto (2010-2023)
-- [Capacità rinnovabile](/dataset/capacita-rinnovabile) — potenza installata per regione e fonte (Terna)
-- [Spesa farmaceutica](/dataset/spesa-farmaceutica) — spesa e consumo SSN per regione e classe ATC
-- [Entrate dello Stato](/dataset/entrate-stato) — previsioni definitive per titolo (BDAP RGS)
-- [Pensioni INPS](/dataset/pensioni-inps) — numero pensioni per gestione e area geografica
+<div class="grid grid-cols-2">
+${themes.map(t => `
+  <div class="card">
+    <h3><a href="/temi/${t.slug}">${t.name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${t.description}</p>
+    <p style="font-size:0.85em">${t.datasets.length} dataset · ${t.questions.length} domande</p>
+  </div>
+`).join("")}
+</div>
+
+---
+
+## Tutti i dataset
+
+```js
+const stageFilter = view(Inputs.select(
+  ["Tutti", "published", "incubating"],
+  {label: "Filtra per stato", value: "Tutti"}
+));
+```
+
+```js
+const filtered = stageFilter === "Tutti"
+  ? catalog.datasets
+  : catalog.datasets.filter(d => d.stage === stageFilter);
+```
+
+```js
+Inputs.table(filtered, {
+  columns: ["slug", "name", "stage", "years", "source"],
+  header: {slug: "ID", name: "Nome", stage: "Stato", years: "Anni", source: "Fonte"},
+  format: {stage: d => d === "published" ? "✅ Pubblicato" : "🔬 Incubazione"},
+  sort: "slug",
+  rows: 30,
+  width: "100%",
+})
+```
 
 <div style="margin-top: 2em; opacity: 0.6; font-size: 0.85em;">
-Catalogo aggiornato: ${catalog.updated_at} · 
-<a href="https://github.com/dataciviclab/dataset-incubator/tree/main/registry">clean_catalog.json</a>
+Catalogo aggiornato: ${catalog.updated_at}
 </div>

--- a/src/index.md
+++ b/src/index.md
@@ -20,15 +20,15 @@ const themes = await FileAttachment("data/themes.json").json();
 
 ## Temi
 
-<div class="grid grid-cols-2">
-${themes.map(t => `
-  <div class="card">
+```js
+display(html`<div class="grid grid-cols-2">
+  ${themes.map(t => html`<div class="card">
     <h3><a href="/temi/${t.slug}">${t.name}</a></h3>
     <p style="opacity:0.7; font-size:0.9em">${t.description}</p>
     <p style="font-size:0.85em">${t.datasets.length} dataset · ${t.questions.length} domande</p>
-  </div>
-`).join("")}
-</div>
+  </div>`)}
+</div>`)
+```
 
 ---
 

--- a/src/temi/finanza-pubblica.md
+++ b/src/temi/finanza-pubblica.md
@@ -1,0 +1,11 @@
+---
+title: Finanza pubblica
+description: Entrate dello Stato, capacità fiscale e tributi locali
+---
+
+# Finanza pubblica
+
+Questo tema raccoglie dataset su finanza pubblica e tributi.
+
+- [IRPEF comunale](/dataset/irpef-comunale)
+- [Entrate dello Stato](/dataset/entrate-stato)

--- a/src/temi/giustizia.md
+++ b/src/temi/giustizia.md
@@ -1,0 +1,10 @@
+---
+title: Giustizia
+description: Flussi civili, tempi e carichi dei tribunali
+---
+
+# Giustizia
+
+Questo tema raccoglie dataset su giustizia e flussi civili.
+
+- [Flussi giustizia civile](/dataset/flussi-giustizia-civile)

--- a/src/temi/sanita.md
+++ b/src/temi/sanita.md
@@ -1,0 +1,10 @@
+---
+title: Sanità
+description: Spesa farmaceutica, consumi sanitari e prevenzione
+---
+
+# Sanità
+
+Questo tema raccoglie dataset su sanità e spesa farmaceutica.
+
+- [Spesa farmaceutica](/dataset/spesa-farmaceutica)

--- a/src/temi/territorio-ambiente.md
+++ b/src/temi/territorio-ambiente.md
@@ -1,0 +1,11 @@
+---
+title: Territorio e ambiente
+description: Trasformazioni territoriali, ambiente, energia e rifiuti
+---
+
+# Territorio e ambiente
+
+Questo tema raccoglie dataset su ambiente, rifiuti ed energia.
+
+- [Rifiuti urbani](/dataset/rifiuti-urbani)
+- [Capacità rinnovabile](/dataset/capacita-rinnovabile)

--- a/src/temi/welfare-lavoro.md
+++ b/src/temi/welfare-lavoro.md
@@ -1,0 +1,11 @@
+---
+title: Welfare e lavoro
+description: Pubblico impiego, pensioni e previdenza
+---
+
+# Welfare e lavoro
+
+Questo tema raccoglie dataset su lavoro, pensioni e pubblico impiego.
+
+- [Dipendenti pubblici](/dataset/dipendenti-pubblici)
+- [Pensioni INPS](/dataset/pensioni-inps)


### PR DESCRIPTION
Aggiunge pagine tematiche per organizzare i dataset per tema editoriale.

- [x] `src/data/themes.json.py` — data loader con 5 temi, slug, domande civiche
- [x] `src/temi/` — 5 pagine con descrizione e link ai dataset
- [x] Index aggiornato: card temi + filtro catalogo

| Tema | Dataset |
|---|---|
| Territorio e ambiente | Rifiuti urbani, Capacità rinnovabile |
| Finanza pubblica | IRPEF comunale, Entrate Stato |
| Sanità | Spesa farmaceutica |
| Welfare e lavoro | Dipendenti pubblici, Pensioni INPS |
| Giustizia | Flussi giustizia civile |

**PR #98** (migrazione Observable) è già mergiata. Questa è un'aggiunta successiva.