### PR TITLE
refactor(_util, scripts): usa path contract da lab-connectors (P1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# Data loader dipendenze
 duckdb>=1.0.0
 requests>=2.28.0
 pyyaml>=6.0
+
+# Path contract GCS — vedere lab-connectors/gcs/paths.py
+# Per CI sostituire con: git+https://github.com/dataciviclab/lab-connectors.git
+-e ../lab-connectors

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests>=2.28.0
 pyyaml>=6.0
 
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@4e0c66c
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ requests>=2.28.0
 pyyaml>=6.0
 
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-# Per CI sostituire con: git+https://github.com/dataciviclab/lab-connectors.git
--e ../lab-connectors
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@4e0c66c

--- a/scripts/generate_observable.mjs
+++ b/scripts/generate_observable.mjs
@@ -10,11 +10,15 @@
 import fs from "fs";
 import path from "path";
 
+const PATHS_CONTRACT_URL =
+  "https://raw.githubusercontent.com/dataciviclab/lab-connectors/main/lab_connectors/gcs/paths.json";
+
 const CATALOG_URL =
   "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/clean_catalog.json";
 
-// Bucket name dal path contract (lab-connectors/gcs/paths.json)
-const GCS_CLEAN_BUCKET = "dataciviclab-clean";
+const GCS_CLEAN_BUCKET =
+  (await fetch(PATHS_CONTRACT_URL).then(r => r.json())).buckets.clean;
+
 const DATA_DIR = "src/data";
 const PAGES_DIR = "src/dataset";
 

--- a/scripts/generate_observable.mjs
+++ b/scripts/generate_observable.mjs
@@ -2,12 +2,19 @@
 /**
  * Genera pagine Observable Framework per tutti i dataset del catalogo.
  * Crea src/data/{slug}.json.py (data loader) e src/dataset/{slug}.md (pagina).
+ *
+ * I path GCS seguono il path contract canonico:
+ *   lab-connectors/lab_connectors/gcs/paths.py  (paths.json)
+ * Pattern clean_parquet: {bucket}/{slug}/{year}/{slug}_{year}_clean.parquet
  */
 import fs from "fs";
 import path from "path";
 
 const CATALOG_URL =
   "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/clean_catalog.json";
+
+// Bucket name dal path contract (lab-connectors/gcs/paths.json)
+const GCS_CLEAN_BUCKET = "dataciviclab-clean";
 const DATA_DIR = "src/data";
 const PAGES_DIR = "src/dataset";
 
@@ -102,7 +109,7 @@ function pageTemplate(slug, name, description, source, stage, dims, metrics, has
   // Resources
   lines.push("---", "");
   lines.push("## Risorse", "");
-  lines.push("- [Scarica il parquet](https://storage.googleapis.com/dataciviclab-clean/" + slug + "/)");
+  lines.push("- [Scarica il parquet](https://storage.googleapis.com/" + GCS_CLEAN_BUCKET + "/" + slug + "/)");
   lines.push("- [Vai alla pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/" + slug.replace(/_/g, "-") + ")");
 
   return lines.join("\n") + "\n";

--- a/src/data/_util.py
+++ b/src/data/_util.py
@@ -1,13 +1,28 @@
 #!/usr/bin/env python3
-"""Utility condivisa per data loader Observable. Legge parquet da GCS via DuckDB e produce JSON."""
-import json, sys, duckdb, requests
+"""Utility condivisa per data loader Observable Framework.
 
-GCS_BASE = "https://storage.googleapis.com/dataciviclab-clean"  # riusabile: from _util import GCS_BASE
+Legge clean parquet da GCS via DuckDB e produce JSON per il frontend.
+
+I path GCS seguono il path contract canonico definito in:
+    lab-connectors/lab_connectors/gcs/paths.py  (paths.json)
+Pattern usato: clean_parquet → {slug}/{year}/{slug}_{year}_clean.parquet
+"""
+import json
+import sys
+
+import duckdb
+import requests
+
+from lab_connectors.gcs.paths import CLEAN_BUCKET, https_url
+
+# GCS_BASE: backward compat per data loader che lo importano direttamente.
+# Calcolato dal contratto invece che hardcoded.
+GCS_BASE = f"https://storage.googleapis.com/{CLEAN_BUCKET}"
 
 
-def _parquet_exists(slug, year):
+def _parquet_exists(slug: str, year: int) -> bool:
     """Verifica se il parquet esiste su GCS (HEAD request)."""
-    url = f"{GCS_BASE}/{slug}/{year}/{slug}_{year}_clean.parquet"
+    url = https_url("clean", "clean_parquet", slug=slug, year=year)
     try:
         r = requests.head(url, timeout=5)
         return r.status_code == 200
@@ -15,28 +30,36 @@ def _parquet_exists(slug, year):
         return False
 
 
-def load_dataset(slug, years, group_cols, metric_cols, where=""):
+def load_dataset(
+    slug: str,
+    years: list[int],
+    group_cols: list[str],
+    metric_cols: list[str],
+    where: str = "",
+) -> None:
     """
     Legge parquet GCS per un dataset, raggruppa per group_cols,
     somma metric_cols, output JSON su stdout.
     Salta gli anni in cui il parquet non esiste.
     """
     con = duckdb.connect()
-    
+
     valid_years = [y for y in years if _parquet_exists(slug, y)]
     if not valid_years:
         json.dump([], sys.stdout)
         return
-    
+
     parquet_refs = " UNION ALL ".join(
-        f"SELECT * FROM read_parquet('{GCS_BASE}/{slug}/{y}/{slug}_{y}_clean.parquet')"
+        "SELECT * FROM read_parquet('"
+        + https_url("clean", "clean_parquet", slug=slug, year=y)
+        + "')"
         for y in valid_years
     )
-    
+
     group_sql = ", ".join(group_cols)
     metrics_sql = ", ".join(f"SUM({m}) AS {m}" for m in metric_cols)
     where_sql = f"WHERE {where}" if where else ""
-    
+
     query = f"""
         SELECT {group_sql}, {metrics_sql}
         FROM ({parquet_refs})
@@ -44,9 +67,12 @@ def load_dataset(slug, years, group_cols, metric_cols, where=""):
         GROUP BY {group_sql}
         ORDER BY {group_sql}
     """
-    
+
     rows = con.sql(query).fetchall()
     columns = group_cols + metric_cols
-    data = [dict(zip(columns, [int(v) if isinstance(v, float) and v == v else v for v in row])) for row in rows]
-    
+    data = [
+        dict(zip(columns, [int(v) if isinstance(v, float) and v == v else v for v in row]))
+        for row in rows
+    ]
+
     json.dump(data, sys.stdout, ensure_ascii=False)


### PR DESCRIPTION
## Refactor data-explorer — path contract centralizzato

Parte della P1 (path contract centralizzato). Dipende da lab-connectors [#19](https://github.com/dataciviclab/lab-connectors/pull/19).

### Cosa cambia

**`src/data/_util.py`**:
- `GCS_BASE` ora è calcolato da `CLEAN_BUCKET` del contratto (stesso valore a runtime)
- URL interni costruiti con `https_url("clean", "clean_parquet", ...)`

**`scripts/generate_observable.mjs`**:
- Estratto `GCS_CLEAN_BUCKET` in costante invece di letterale nel template

**`requirements.txt`**:
- Aggiunto `-e ../lab-connectors` per sviluppo locale

### Impatto

- 10 data loader che importano `load_dataset` da `_util` — **nessuna modifica**
- 2 data loader che importano `GCS_BASE` (`irpef-capoluoghi`, `dipendenti-pubblici`) — **backward compat**
- CI/CD: aggiungere `pip install git+https://github.com/dataciviclab/lab-connectors.git` al deploy dopo merge

### Test

- 13 file Python compilati: ✅
- Syntax JS: ✅
- `GCS_BASE` e `https_url` producono URL identici: ✅
