### PR TITLE
feat(bdap-lea): aggiungi dataset explorer e catalogo

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -8,6 +8,7 @@ export default {
       collapsible: false,
       pages: [
         { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
+        { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
         { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
         { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },
         { name: "Dipendenti pubblici", path: "/dataset/dipendenti-pubblici" },

--- a/src/data/bdap-lea-macro.json.py
+++ b/src/data/bdap-lea-macro.json.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Data loader: BDAP LEA — spesa per regione e macro-area (prevenzione, distrettuale, ospedaliera, ricerca)."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="bdap_lea",
+    years=[2024],
+    group_cols=["descrizione_regione", "descrizione_voce_contabile"],
+    metric_cols=["importo_totale"],
+    where="codice_voce_contabile IN ('19999', '29999', '39999', '48888')",
+)

--- a/src/data/bdap-lea-regioni.json.py
+++ b/src/data/bdap-lea-regioni.json.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Data loader: BDAP LEA — totale spesa per regione."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="bdap_lea",
+    years=[2024],
+    group_cols=["descrizione_regione"],
+    metric_cols=["importo_totale"],
+    where="codice_voce_contabile = '49999'",
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -21,8 +21,8 @@ themes = [
         "slug": "sanita",
         "name": "Sanità",
         "description": "Spesa farmaceutica, consumi sanitari e prevenzione",
-        "datasets": ["spesa-farmaceutica"],
-        "questions": ["Come cambia tra regioni la spesa farmaceutica per classi terapeutiche?"],
+        "datasets": ["spesa-farmaceutica", "bdap-lea"],
+        "questions": ["Come cambia tra regioni la spesa farmaceutica per classi terapeutiche?", "Quanto spendono le regioni per i Livelli Essenziali di Assistenza?"],
     },
     {
         "slug": "welfare-lavoro",

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -1,0 +1,139 @@
+---
+title: Spesa sanitaria regionale LEA
+description: Dati BDAP sui costi dei Livelli Essenziali di Assistenza per regione, macro-area e voce contabile
+---
+
+# Spesa sanitaria regionale LEA
+
+I costi sostenuti dalle regioni italiane per garantire i Livelli Essenziali di Assistenza (LEA), disaggregati per ente, macro-area (prevenzione, assistenza distrettuale, ospedaliera e ricerca) e voce contabile.
+
+**Fonte**: BDAP — Banca Dati delle Amministrazioni Pubbliche · **Periodo**: 2024
+
+```js
+const regioni = await FileAttachment("../data/bdap-lea-regioni.json").json();
+const macro = await FileAttachment("../data/bdap-lea-macro.json").json();
+```
+
+```js
+const totSpesa = d3.sum(regioni, d => d.importo_totale);
+const nRegioni = regioni.length;
+const mediaRegione = totSpesa / nRegioni;
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Spesa totale LEA</h3>
+    <span class="big">€ ${(totSpesa / 1e9).toFixed(1)} <small style="opacity:0.6">mld</small></span>
+  </div>
+  <div class="card">
+    <h3>Media per regione</h3>
+    <span class="big">€ ${(mediaRegione / 1e9).toFixed(2)} <small style="opacity:0.6">mld</small></span>
+  </div>
+  <div class="card">
+    <h3>Regioni</h3>
+    <span class="big">${nRegioni}</span>
+  </div>
+</div>
+
+---
+
+## Spesa per regione
+
+Quanto spende ciascuna regione per i LEA? Le regioni più popolose guidano la classifica, ma il dato pro capite — non ancora presente in questo dataset — darebbe un quadro più preciso dell'efficienza.
+
+```js
+const ordinato = regioni
+  .sort((a, b) => b.importo_totale - a.importo_totale)
+  .map(d => ({...d, spesa_mld: d.importo_totale / 1e9}));
+```
+
+```js
+Plot.plot({
+  title: "Spesa LEA per regione — 2024",
+  width: 800,
+  height: 450,
+  marginLeft: 140,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "miliardi di €", tickFormat: "~s"},
+  color: {scheme: "Blues"},
+  marks: [
+    Plot.barX(ordinato, {
+      y: "descrizione_regione",
+      x: "importo_totale",
+      fill: "importo_totale",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Composizione della spesa per macro-area
+
+Come si distribuisce la spesa tra le quattro macro-aree? In tutte le regioni l'assistenza distrettuale e ospedaliera assorbono la quasi totalità delle risorse, mentre prevenzione e ricerca pesano in misura marginale.
+
+```js
+const macroLabel = {
+  "TOTALE PREVENZIONE COLLETTIVA E SANITA' PUBBLICA": "Prevenzione e sanità pubblica",
+  "TOTALE ASSISTENZA DISTRETTUALE": "Assistenza distrettuale",
+  "TOTALE ASSISTENZA OSPEDALIERA": "Assistenza ospedaliera",
+  "TOTALE COSTI PER ATTIVITA' DI RICERCA": "Ricerca"
+};
+
+const macroShort = macro.map(d => ({
+  ...d,
+  macro: macroLabel[d.descrizione_voce_contabile] || d.descrizione_voce_contabile
+}));
+```
+
+```js
+// Top 5 regioni per spesa totale + composizione
+const top5 = ordinato.slice(0, 5).map(d => d.descrizione_regione);
+const macroTop5 = macroShort.filter(d => top5.includes(d.descrizione_regione));
+```
+
+```js
+Plot.plot({
+  title: "Composizione spesa LEA — top 5 regioni (2024)",
+  width: 800,
+  height: 350,
+  marginLeft: 120,
+  color: {legend: true, scheme: "Set2"},
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "miliardi di €", tickFormat: d => (d / 1e9).toFixed(0)},
+  marks: [
+    Plot.barX(macroTop5, {
+      y: "descrizione_regione",
+      x: "importo_totale",
+      fill: "macro",
+      sort: {y: "-x"},
+      tip: {format: {x: d => `€ ${(d / 1e6).toFixed(0)} mln`}}
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Dettaglio regioni
+
+```js
+Inputs.table(ordinato, {
+  columns: ["descrizione_regione", "importo_totale"],
+  header: {descrizione_regione: "Regione", importo_totale: "Spesa totale (€)"},
+  format: {importo_totale: x => `€ ${Math.round(x).toLocaleString("it-IT")}`},
+  rows: 25,
+  width: "100%"
+})
+```
+
+---
+
+## Risorsa
+
+- [BDAP — Open Data](https://bdap-opendata.rgs.mef.gov.it/)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-lea)

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -1,6 +1,8 @@
 ---
 title: Spesa sanitaria regionale LEA
 description: Dati BDAP sui costi dei Livelli Essenziali di Assistenza per regione, macro-area e voce contabile
+source: BDAP — Banca Dati delle Amministrazioni Pubbliche
+last_modified: 2025-06-30
 ---
 
 # Spesa sanitaria regionale LEA
@@ -133,7 +135,8 @@ Inputs.table(ordinato, {
 
 ---
 
-## Risorsa
+## Risorse
 
 - [BDAP — Open Data](https://bdap-opendata.rgs.mef.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_lea/2024/bdap_lea_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-lea)


### PR DESCRIPTION
## Cosa

Pagina dataset per **BDAP LEA** — spesa sanitaria regionale per i Livelli Essenziali di Assistenza.

Closes #91.

### File creati

| File | Ruolo |
|------|-------|
| `src/data/bdap-lea-regioni.json.py` | Loader: spesa totale LEA per regione |
| `src/data/bdap-lea-macro.json.py` | Loader: spesa per regione e macro-area |
| `src/dataset/bdap-lea.md` | Pagina dataset con 2 chart + tabella |

### File modificati

- `observablehq.config.js` — registrata pagina `/dataset/bdap-lea`
- `src/data/themes.json.py` — aggiunto `bdap-lea` al tema **Sanità**

### Struttura pagina

1. KPI card: spesa totale (€330.9 mld), media, regioni
2. Bar chart: spesa per regione (Blues, ordinata)
3. Bar chart: composizione macro per top 5 regioni (Set2)
4. Tabella dettaglio regioni
5. Risorse e link pipeline

### Dati

- 21 regioni, anno 2024
- 4 macro-aree: distrettuale (€175.7 mld), ospedaliera (€141.0 mld), prevenzione (€13.3 mld), ricerca (€0.9 mld)
