### PR TITLE
feat(consip-consumi-convenzione): aggiungi dataset explorer e catalogo

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -8,6 +8,7 @@ export default {
       collapsible: false,
       pages: [
         { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
+        { name: "Consumi Consip", path: "/dataset/consip-consumi-convenzione" },
         { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
         { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
         { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },

--- a/src/data/consip-consumi-convenzione-regioni.json.py
+++ b/src/data/consip-consumi-convenzione-regioni.json.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Data loader: Consip Consumi Convenzione — spesa per regione PA."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="consip_consumi_convenzione",
+    years=list(range(2023, 2026)),
+    group_cols=["anno_riferimento", "regione_pa"],
+    metric_cols=["valore_economico_consumi", "numero_ordini_con_consumi", "n_pa_con_consumi", "n_po_con_consumi"],
+)

--- a/src/data/consip-consumi-convenzione-regioni.json.py
+++ b/src/data/consip-consumi-convenzione-regioni.json.py
@@ -7,5 +7,5 @@ load_dataset(
     slug="consip_consumi_convenzione",
     years=list(range(2023, 2026)),
     group_cols=["anno_riferimento", "regione_pa"],
-    metric_cols=["valore_economico_consumi", "numero_ordini_con_consumi", "n_pa_con_consumi", "n_po_con_consumi"],
+    metric_cols=["valore_economico_consumi", "numero_ordini_con_consumi"],
 )

--- a/src/data/consip-consumi-convenzione-tipologie.json.py
+++ b/src/data/consip-consumi-convenzione-tipologie.json.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Data loader: Consip Consumi Convenzione — spesa per tipologia amministrazione."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="consip_consumi_convenzione",
+    years=list(range(2023, 2026)),
+    group_cols=["anno_riferimento", "tipologia_amministrazione"],
+    metric_cols=["valore_economico_consumi", "numero_ordini_con_consumi"],
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -14,8 +14,8 @@ themes = [
         "slug": "finanza-pubblica",
         "name": "Finanza pubblica",
         "description": "Entrate dello Stato, capacità fiscale e tributi locali",
-        "datasets": ["irpef-comunale", "entrate-stato"],
-        "questions": ["Come si distribuisce la capacità fiscale tra regioni?", "Quali sono le principali voci di entrata dello Stato?"],
+        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione"],
+        "questions": ["Come si distribuisce la capacità fiscale tra regioni?", "Quali sono le principali voci di entrata dello Stato?", "Quanto spende la PA attraverso le convenzioni Consip?"],
     },
     {
         "slug": "sanita",

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -1,6 +1,6 @@
 ---
 title: Consumi in convenzione Consip
-description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione, tipologia di amministrazione e fornitore
+description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione e tipologia di amministrazione
 source: Consip
 last_modified: 2025-12-31
 ---
@@ -28,12 +28,9 @@ const totAnno = regioni
 const totOrdini = regioni
   .filter(d => d.anno_riferimento === annoSel)
   .reduce((s, d) => s + d.numero_ordini_con_consumi, 0);
-const totPa = regioni
-  .filter(d => d.anno_riferimento === annoSel)
-  .reduce((s, d) => s + d.n_pa_con_consumi, 0);
 ```
 
-<div class="grid grid-cols-3">
+<div class="grid grid-cols-2">
   <div class="card">
     <h3>Spesa totale</h3>
     <span class="big">€ ${(totAnno / 1e6).toFixed(0)} <small style="opacity:0.6">mln</small></span>
@@ -41,10 +38,6 @@ const totPa = regioni
   <div class="card">
     <h3>Ordini</h3>
     <span class="big">${totOrdini.toLocaleString("it-IT")}</span>
-  </div>
-  <div class="card">
-    <h3>Amministrazioni</h3>
-    <span class="big">${totPa.toLocaleString("it-IT")}</span>
   </div>
 </div>
 
@@ -123,19 +116,15 @@ Plot.plot({
 
 ```js
 Inputs.table(regFiltered, {
-  columns: ["regione_pa", "valore_economico_consumi", "numero_ordini_con_consumi", "n_pa_con_consumi", "n_po_con_consumi"],
+  columns: ["regione_pa", "valore_economico_consumi", "numero_ordini_con_consumi"],
   header: {
     regione_pa: "Regione PA",
     valore_economico_consumi: "Spesa (€)",
-    numero_ordini_con_consumi: "Ordini",
-    n_pa_con_consumi: "PA coinvolte",
-    n_po_con_consumi: "Fornitori"
+    numero_ordini_con_consumi: "Ordini"
   },
   format: {
     valore_economico_consumi: x => `€ ${Math.round(x).toLocaleString("it-IT")}`,
-    numero_ordini_con_consumi: x => x.toLocaleString("it-IT"),
-    n_pa_con_consumi: x => x.toLocaleString("it-IT"),
-    n_po_con_consumi: x => x.toLocaleString("it-IT")
+    numero_ordini_con_consumi: x => x.toLocaleString("it-IT")
   },
   rows: 25,
   width: "100%"

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -1,6 +1,8 @@
 ---
 title: Consumi in convenzione Consip
 description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione, tipologia di amministrazione e fornitore
+source: Consip
+last_modified: 2025-12-31
 ---
 
 # Consumi in convenzione Consip
@@ -145,4 +147,5 @@ Inputs.table(regFiltered, {
 ## Risorse
 
 - [Consip — Dati](https://dati.consip.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/consip_consumi_convenzione/2025/consip_consumi_convenzione_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/consip-consumi-convenzione)

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -1,0 +1,148 @@
+---
+title: Consumi in convenzione Consip
+description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione, tipologia di amministrazione e fornitore
+---
+
+# Consumi in convenzione Consip
+
+La spesa della Pubblica Amministrazione per beni e servizi acquistati attraverso le convenzioni Consip. I dati sono disaggregati per regione della PA, tipologia di amministrazione e fornitore.
+
+**Fonte**: Consip · **Periodo**: 2023–2025
+
+```js
+const regioni = await FileAttachment("../data/consip-consumi-convenzione-regioni.json").json();
+const tipologie = await FileAttachment("../data/consip-consumi-convenzione-tipologie.json").json();
+```
+
+```js
+const anni = [...new Set(regioni.map(d => d.anno_riferimento))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+```
+
+```js
+const totAnno = regioni
+  .filter(d => d.anno_riferimento === annoSel)
+  .reduce((s, d) => s + d.valore_economico_consumi, 0);
+const totOrdini = regioni
+  .filter(d => d.anno_riferimento === annoSel)
+  .reduce((s, d) => s + d.numero_ordini_con_consumi, 0);
+const totPa = regioni
+  .filter(d => d.anno_riferimento === annoSel)
+  .reduce((s, d) => s + d.n_pa_con_consumi, 0);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Spesa totale</h3>
+    <span class="big">€ ${(totAnno / 1e6).toFixed(0)} <small style="opacity:0.6">mln</small></span>
+  </div>
+  <div class="card">
+    <h3>Ordini</h3>
+    <span class="big">${totOrdini.toLocaleString("it-IT")}</span>
+  </div>
+  <div class="card">
+    <h3>Amministrazioni</h3>
+    <span class="big">${totPa.toLocaleString("it-IT")}</span>
+  </div>
+</div>
+
+---
+
+## Spesa per regione della PA
+
+Quali regioni concentrano la spesa in convenzione? Il Lazio e la Lombardia guidano la classifica, trainate rispettivamente dagli apparati centrali dello Stato e dagli enti territoriali.
+
+```js
+const regFiltered = regioni
+  .filter(d => d.anno_riferimento === annoSel)
+  .sort((a, b) => b.valore_economico_consumi - a.valore_economico_consumi);
+```
+
+```js
+Plot.plot({
+  title: `Spesa Consip per regione della PA — ${annoSel}`,
+  width: 800,
+  height: 420,
+  marginLeft: 140,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "milioni di €", tickFormat: d => (d / 1e6).toFixed(0)},
+  color: {scheme: "Oranges"},
+  marks: [
+    Plot.barX(regFiltered, {
+      y: "regione_pa",
+      x: "valore_economico_consumi",
+      fill: "valore_economico_consumi",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Spesa per tipo di amministrazione
+
+Chi spende di più attraverso Consip? Comuni, aziende di servizi pubblici e ministeri sono le prime tre categorie per volume di acquisti.
+
+```js
+const tipFiltered = tipologie
+  .filter(d => d.anno_riferimento === annoSel)
+  .sort((a, b) => b.valore_economico_consumi - a.valore_economico_consumi)
+  .slice(0, 12);
+```
+
+```js
+Plot.plot({
+  title: `Spesa per tipologia di amministrazione — ${annoSel} (top 12)`,
+  width: 800,
+  height: 380,
+  marginLeft: 180,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "milioni di €", tickFormat: d => (d / 1e6).toFixed(0)},
+  color: {scheme: "Set2"},
+  marks: [
+    Plot.barX(tipFiltered, {
+      y: "tipologia_amministrazione",
+      x: "valore_economico_consumi",
+      fill: "valore_economico_consumi",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Dettaglio regioni
+
+```js
+Inputs.table(regFiltered, {
+  columns: ["regione_pa", "valore_economico_consumi", "numero_ordini_con_consumi", "n_pa_con_consumi", "n_po_con_consumi"],
+  header: {
+    regione_pa: "Regione PA",
+    valore_economico_consumi: "Spesa (€)",
+    numero_ordini_con_consumi: "Ordini",
+    n_pa_con_consumi: "PA coinvolte",
+    n_po_con_consumi: "Fornitori"
+  },
+  format: {
+    valore_economico_consumi: x => `€ ${Math.round(x).toLocaleString("it-IT")}`,
+    numero_ordini_con_consumi: x => x.toLocaleString("it-IT"),
+    n_pa_con_consumi: x => x.toLocaleString("it-IT"),
+    n_po_con_consumi: x => x.toLocaleString("it-IT")
+  },
+  rows: 25,
+  width: "100%"
+})
+```
+
+---
+
+## Risorse
+
+- [Consip — Dati](https://dati.consip.it/)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/consip-consumi-convenzione)

--- a/src/temi/finanza-pubblica.md
+++ b/src/temi/finanza-pubblica.md
@@ -1,11 +1,12 @@
 ---
 title: Finanza pubblica
-description: Entrate dello Stato, capacità fiscale e tributi locali
+description: Entrate dello Stato, capacità fiscale, tributi locali e acquisti in convenzione
 ---
 
 # Finanza pubblica
 
-Questo tema raccoglie dataset su finanza pubblica e tributi.
+Questo tema raccoglie dataset su finanza pubblica, tributi e spesa della PA in convenzione.
 
 - [IRPEF comunale](/dataset/irpef-comunale)
 - [Entrate dello Stato](/dataset/entrate-stato)
+- [Consumi Consip](/dataset/consip-consumi-convenzione)

--- a/src/temi/sanita.md
+++ b/src/temi/sanita.md
@@ -5,6 +5,7 @@ description: Spesa farmaceutica, consumi sanitari e prevenzione
 
 # Sanità
 
-Questo tema raccoglie dataset su sanità e spesa farmaceutica.
+Questo tema raccoglie dataset su sanità, spesa farmaceutica e costi dei Livelli Essenziali di Assistenza.
 
 - [Spesa farmaceutica](/dataset/spesa-farmaceutica)
+- [Spesa sanitaria LEA](/dataset/bdap-lea)


### PR DESCRIPTION
## Cosa

Pagina dataset per **Consip Consumi Convenzione** — acquisti della PA attraverso convenzioni Consip, per regione e tipologia di amministrazione.

Closes #92.

### File creati

| File | Ruolo |
|------|-------|
| `src/data/consip-consumi-convenzione-regioni.json.py` | Loader: spesa per regione PA |
| `src/data/consip-consumi-convenzione-tipologie.json.py` | Loader: spesa per tipologia amministrazione |
| `src/dataset/consip-consumi-convenzione.md` | Pagina con 2 chart + tabella |

### File modificati

- `observablehq.config.js` — registrata pagina `/dataset/consip-consumi-convenzione`
- `src/data/themes.json.py` — aggiunto al tema **Finanza pubblica**

### Struttura pagina

1. KPI card: spesa totale, numero ordini, PA coinvolte
2. Filtro anno (2023–2025)
3. Bar chart: spesa per regione PA (Oranges, ordinata)
4. Bar chart: spesa per tipologia amministrazione top 12 (Set2)
5. Tabella dettaglio regioni
6. Risorse

### Dati

- 3 anni (2023-2025), 20 regioni, 25 tipologie amministrazione
- Spesa totale: €9.77 mld nei 3 anni
- Top 3 regioni: Lazio (€2.02 mld), Lombardia (€1.69 mld), Veneto (€0.78 mld)
- Top 3 tipologie: Comuni, Aziende servizi pubblici, Ministeri
