### PR TITLE
feat(tema): tema air (light) + ocean-floor (dark)

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -2,6 +2,7 @@ export default {
   root: "src",
   output: "dist/observable",
   title: "DataCivicLab Explorer",
+  theme: ["air", "ocean-floor"],
   pages: [
     {
       name: "Dataset",


### PR DESCRIPTION
## Cosa

Imposta il tema Observable Framework su `["air", "ocean-floor"]`:
- **Light mode**: `air` — bianco pulito, accenti blu, vicino alla palette DCL
- **Dark mode**: `ocean-floor` — blu scuro profondo

Il cambio è automatico via `prefers-color-scheme` (preferenze di sistema).

## Note

- `app.css` è stato lasciato invariato — le sue direttive Tailwind/DaisyUI sono inattive (nessun PostCSS configurato)
- Logo nell'header non è ancora implementato (servirebbe un meccanismo custom)
- `static/favicon.ico` e `static/icon.svg` già presenti per la tab del browser

## Gate pre-merge

- [x] build passa
- [x] 10 pagine validate
- [x] tema applicato: `theme-air,ocean-floor` nel build output
