### PR TITLE
fix(bdap-lea): data loader non usa più voci totale rimosse

### DIFF
--- a/src/data/bdap-lea-macro.json.py
+++ b/src/data/bdap-lea-macro.json.py
@@ -21,18 +21,22 @@ con = duckdb.connect()
 rows = con.sql(f"""
     SELECT
         descrizione_regione,
-        CASE LEFT(codice_voce_contabile, 1)
-            WHEN '1' THEN 'Prevenzione e sanità pubblica'
-            WHEN '2' THEN 'Assistenza distrettuale'
-            WHEN '3' THEN 'Assistenza ospedaliera'
-            WHEN '4' THEN 'Ricerca'
-        END AS descrizione_voce_contabile,
+        macro_area AS descrizione_voce_contabile,
         SUM(importo_totale) AS importo_totale
-    FROM read_parquet('{url}')
+    FROM (
+        SELECT *,
+            CASE LEFT(codice_voce_contabile, 1)
+                WHEN '1' THEN 'Prevenzione e sanità pubblica'
+                WHEN '2' THEN 'Assistenza distrettuale'
+                WHEN '3' THEN 'Assistenza ospedaliera'
+                WHEN '4' THEN 'Ricerca'
+            END AS macro_area
+        FROM read_parquet('{url}')
+    )
     WHERE codice_ente_ssn <> '000'
-      AND LEFT(codice_voce_contabile, 1) IN ('1', '2', '3', '4')
-    GROUP BY descrizione_regione, descrizione_voce_contabile
-    ORDER BY descrizione_regione, descrizione_voce_contabile
+      AND macro_area IS NOT NULL
+    GROUP BY descrizione_regione, macro_area
+    ORDER BY descrizione_regione, macro_area
 """).fetchall()
 
 data = [

--- a/src/data/bdap-lea-macro.json.py
+++ b/src/data/bdap-lea-macro.json.py
@@ -1,12 +1,47 @@
 #!/usr/bin/env python3
-"""Data loader: BDAP LEA — spesa per regione e macro-area (prevenzione, distrettuale, ospedaliera, ricerca)."""
-import sys; sys.path.insert(0, "src/data")
-from _util import load_dataset
+"""Data loader: BDAP LEA — spesa per regione e macro-area (prevenzione, distrettuale, ospedaliera, ricerca).
 
-load_dataset(
-    slug="bdap_lea",
-    years=[2024],
-    group_cols=["descrizione_regione", "descrizione_voce_contabile"],
-    metric_cols=["importo_totale"],
-    where="codice_voce_contabile IN ('19999', '29999', '39999', '48888')",
-)
+Deriva la macro-area dal primo carattere del codice voce contabile:
+  1 = Prevenzione collettiva e sanità pubblica
+  2 = Assistenza distrettuale
+  3 = Assistenza ospedaliera
+  (4 = Ricerca — non ha voci di dettaglio nei dati correnti)
+"""
+import json
+import sys
+import duckdb
+
+from lab_connectors.gcs.paths import https_url
+
+slug = "bdap_lea"
+year = 2024
+url = https_url("clean", "clean_parquet", slug=slug, year=year)
+
+con = duckdb.connect()
+rows = con.sql(f"""
+    SELECT
+        descrizione_regione,
+        CASE LEFT(codice_voce_contabile, 1)
+            WHEN '1' THEN 'Prevenzione e sanità pubblica'
+            WHEN '2' THEN 'Assistenza distrettuale'
+            WHEN '3' THEN 'Assistenza ospedaliera'
+            WHEN '4' THEN 'Ricerca'
+        END AS descrizione_voce_contabile,
+        SUM(importo_totale) AS importo_totale
+    FROM read_parquet('{url}')
+    WHERE codice_ente_ssn <> '000'
+      AND LEFT(codice_voce_contabile, 1) IN ('1', '2', '3', '4')
+    GROUP BY descrizione_regione, descrizione_voce_contabile
+    ORDER BY descrizione_regione, descrizione_voce_contabile
+""").fetchall()
+
+data = [
+    {
+        "descrizione_regione": r[0],
+        "descrizione_voce_contabile": r[1],
+        "importo_totale": float(r[2]),
+    }
+    for r in rows
+]
+
+json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/bdap-lea-regioni.json.py
+++ b/src/data/bdap-lea-regioni.json.py
@@ -8,5 +8,5 @@ load_dataset(
     years=[2024],
     group_cols=["descrizione_regione"],
     metric_cols=["importo_totale"],
-    where="codice_voce_contabile = '49999'",
+    where="codice_ente_ssn <> '000'",
 )

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -78,16 +78,9 @@ Plot.plot({
 Come si distribuisce la spesa tra le quattro macro-aree? In tutte le regioni l'assistenza distrettuale e ospedaliera assorbono la quasi totalità delle risorse, mentre prevenzione e ricerca pesano in misura marginale.
 
 ```js
-const macroLabel = {
-  "TOTALE PREVENZIONE COLLETTIVA E SANITA' PUBBLICA": "Prevenzione e sanità pubblica",
-  "TOTALE ASSISTENZA DISTRETTUALE": "Assistenza distrettuale",
-  "TOTALE ASSISTENZA OSPEDALIERA": "Assistenza ospedaliera",
-  "TOTALE COSTI PER ATTIVITA' DI RICERCA": "Ricerca"
-};
-
 const macroShort = macro.map(d => ({
   ...d,
-  macro: macroLabel[d.descrizione_voce_contabile] || d.descrizione_voce_contabile
+  macro: d.descrizione_voce_contabile
 }));
 ```
 


### PR DESCRIPTION
## Problema

Il clean di bdap-lea ora esclude le voci di totale contabile (19999, 29999, 39999, 48888, 49999). I data loader del frontend filtravano per queste voci (`codice_voce_contabile = '49999'` e `IN ('19999', '29999', '39999', '48888')`), quindi non trovavano più dati — pagina vuota.

## Fix

### `src/data/bdap-lea-regioni.json.py`
- `where` da `codice_voce_contabile = '49999'` a `codice_ente_ssn <> '000'` — somma tutte le voci di dettaglio per regione

### `src/data/bdap-lea-macro.json.py`
- Riscritto con query custom: deriva la macro-area dal primo carattere del codice voce contabile (1=prevenzione, 2=distrettuale, 3=ospedaliera, 4=ricerca)
- Raggruppa per regione + macro-area

### `src/dataset/bdap-lea.md`
- Rimosso `macroLabel` mapping ridondante (nomi già in forma leggibile)

## Test

I data loader sono eseguiti a build-time da Observable Framework. Dopo il merge, il deploy automatico su GitHub Pages ricostruirà il frontend con i dati corretti.