### PR TITLE
feat(bdap-lea): nota esplicativa e tabella regioni arricchita

### DIFF
--- a/src/data/bdap-lea-macro.json.py
+++ b/src/data/bdap-lea-macro.json.py
@@ -33,7 +33,7 @@ rows = con.sql(f"""
             END AS macro_area
         FROM read_parquet('{url}')
     )
-    WHERE codice_ente_ssn <> '000'
+    WHERE codice_ente_ssn NOT IN ('000', '999')
       AND macro_area IS NOT NULL
     GROUP BY descrizione_regione, macro_area
     ORDER BY descrizione_regione, macro_area

--- a/src/data/bdap-lea-regioni.json.py
+++ b/src/data/bdap-lea-regioni.json.py
@@ -7,6 +7,16 @@ load_dataset(
     slug="bdap_lea",
     years=[2024],
     group_cols=["descrizione_regione"],
-    metric_cols=["importo_totale"],
+    metric_cols=[
+        "importo_totale",
+        "prestazioni_sanitarie",
+        "personale_sanitario",
+        "personale_amministrativo",
+        "consumi_sanitari",
+        "servizi_sanitari",
+        "servizi_non_sanitari",
+        "ammortamenti",
+        "altri_costi",
+    ],
     where="codice_ente_ssn <> '000'",
 )

--- a/src/data/bdap-lea-regioni.json.py
+++ b/src/data/bdap-lea-regioni.json.py
@@ -18,5 +18,5 @@ load_dataset(
         "ammortamenti",
         "altri_costi",
     ],
-    where="codice_ente_ssn <> '000'",
+    where="codice_ente_ssn not in ('000', '999')",
 )

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -22,6 +22,8 @@ const nRegioni = regioni.length;
 const mediaRegione = totSpesa / nRegioni;
 ```
 
+> **Nota sul totale**: la spesa complessiva (~€${(totSpesa / 1e9).toFixed(0)} mld) include le **transazioni inter-ente** per mobilità sanitaria (prestazioni acquistate da altri enti SSN, ~€166 mld). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Escludendo questo effetto, il costo operativo diretto è circa €230 mld.
+
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Spesa totale LEA</h3>
@@ -114,13 +116,36 @@ Plot.plot({
 
 ---
 
-## Dettaglio regioni
+## Dettaglio regioni — composizione della spesa
 
 ```js
 Inputs.table(ordinato, {
-  columns: ["descrizione_regione", "importo_totale"],
-  header: {descrizione_regione: "Regione", importo_totale: "Spesa totale (€)"},
-  format: {importo_totale: x => `€ ${Math.round(x).toLocaleString("it-IT")}`},
+  columns: [
+    "descrizione_regione",
+    "importo_totale",
+    "prestazioni_sanitarie",
+    "personale_sanitario",
+    "consumi_sanitari",
+    "servizi_sanitari",
+    "ammortamenti"
+  ],
+  header: {
+    descrizione_regione: "Regione",
+    importo_totale: "Spesa totale (€)",
+    prestazioni_sanitarie: "Prestazioni",
+    personale_sanitario: "Personale",
+    consumi_sanitari: "Consumi",
+    servizi_sanitari: "Servizi",
+    ammortamenti: "Ammortam."
+  },
+  format: {
+    importo_totale: x => `€ ${(x / 1e6).toFixed(0)} mln`,
+    prestazioni_sanitarie: x => `€ ${(x / 1e6).toFixed(0)} mln`,
+    personale_sanitario: x => `€ ${(x / 1e6).toFixed(0)} mln`,
+    consumi_sanitari: x => `€ ${(x / 1e6).toFixed(0)} mln`,
+    servizi_sanitari: x => `€ ${(x / 1e6).toFixed(0)} mln`,
+    ammortamenti: x => `€ ${(x / 1e6).toFixed(0)} mln`
+  },
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -22,7 +22,12 @@ const nRegioni = regioni.length;
 const mediaRegione = totSpesa / nRegioni;
 ```
 
-> **Nota sul totale**: la spesa complessiva (~€${(totSpesa / 1e9).toFixed(0)} mld) include le **transazioni inter-ente** per mobilità sanitaria (prestazioni acquistate da altri enti SSN, ~€166 mld). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Escludendo questo effetto, il costo operativo diretto è circa €230 mld.
+```js
+const totPrestazioni = d3.sum(regioni, d => d.prestazioni_sanitarie);
+const totDiretto = totSpesa - totPrestazioni;
+```
+
+> **Nota sul totale**: la spesa complessiva (~€${(totSpesa / 1e9).toFixed(0)} mld) include le **transazioni inter-ente** per mobilità sanitaria (prestazioni acquistate da altri enti SSN, ~€${(totPrestazioni / 1e9).toFixed(0)} mld). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Escludendo questo effetto, il costo operativo diretto è circa €${(totDiretto / 1e9).toFixed(0)} mld.
 
 <div class="grid grid-cols-3">
   <div class="card">


### PR DESCRIPTION
## Migliorie alla pagina bdap-lea

### 1. Nota sul totale della spesa
Aggiunta una nota esplicativa sotto le summary card che spiega come il totale (~€396 mld) includa le transazioni inter-ente per mobilità sanitaria (~€166 mld in prestazioni). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante — senza questo effetto il costo operativo diretto è ~€230 mld.

### 2. Tabella regioni arricchita
La tabella mostra ora, per ogni regione:
- Spesa totale
- Prestazioni sanitarie (mobilità inter-ente)
- Personale sanitario
- Consumi sanitari
- Servizi sanitari
- Ammortamenti

### Data loader
`bdap-lea-regioni.json.py` ora restituisce anche i principali aggregati di costo (prestazioni, personale, consumi, servizi, ammortamenti) oltre a `importo_totale`.

## Build
`npx observable build` — success, pagina bdap-lea generata senza errori.