### PR TITLE
feat(istat-ipab-aree): aggiungi dataset explorer e catalogo

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -9,6 +9,7 @@ export default {
       collapsible: false,
       pages: [
         { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
+        { name: "Indice prezzi IPAB", path: "/dataset/istat-ipab-aree" },
         { name: "Consumi Consip", path: "/dataset/consip-consumi-convenzione" },
         { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
         { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },

--- a/src/data/istat-ipab-aree.json.py
+++ b/src/data/istat-ipab-aree.json.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Data loader: ISTAT IPAB Aree — indice prezzi per area e trimestre."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="istat_ipab_aree",
+    years=list(range(2010, 2026)),
+    group_cols=["area", "trimestre"],
+    metric_cols=["indice_prezzi"],
+    where="tipo_abitazione = 'EXST_DW'",
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -24,7 +24,7 @@ themes = [
     {
         "slug": "welfare-lavoro",
         "name": "Welfare e lavoro",
-        "description": "Pubblico impiego, pensioni e previdenza",
+        "description": "Pubblico impiego, pensioni, previdenza e prezzi delle abitazioni",
         "datasets": ["dipendenti-pubblici", "pensioni-inps", "istat-ipab-aree"],
     },
     {

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -25,7 +25,7 @@ themes = [
         "slug": "welfare-lavoro",
         "name": "Welfare e lavoro",
         "description": "Pubblico impiego, pensioni e previdenza",
-        "datasets": ["dipendenti-pubblici", "pensioni-inps"],
+        "datasets": ["dipendenti-pubblici", "pensioni-inps", "istat-ipab-aree"],
     },
     {
         "slug": "giustizia",

--- a/src/dataset/istat-ipab-aree.md
+++ b/src/dataset/istat-ipab-aree.md
@@ -113,5 +113,5 @@ Inputs.table(ultimiValori, {
 ## Risorse
 
 - [ISTAT — IPAB](https://www.istat.it/it/archivio/16773)
-- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
+- [Scarica il parquet pulito (2024)](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-ipab-aree)

--- a/src/dataset/istat-ipab-aree.md
+++ b/src/dataset/istat-ipab-aree.md
@@ -1,0 +1,117 @@
+---
+title: Indice prezzi abitazioni (IPAB) per area
+description: Dati ISTAT sull'indice dei prezzi delle abitazioni (IPAB) per area geografica, trimestre e tipologia
+source: ISTAT
+last_modified: 2025-12-31
+---
+
+# Indice prezzi abitazioni (IPAB) per area
+
+L'indice dei prezzi delle abitazioni (IPAB) misura l'evoluzione dei prezzi delle abitazioni sul mercato italiano, disaggregato per macro-area e città (Milano, Roma, Torino).
+
+**Fonte**: ISTAT · **Periodo**: 2010–2025 · Dati trimestrali
+
+```js
+const data = await FileAttachment("../data/istat-ipab-aree.json").json();
+```
+
+```js
+const areeMacro = ["Nord-ovest", "Nord-est", "Centro (I)", "Mezzogiorno", "Italy"];
+const citta = ["Milano", "Roma", "Torino"];
+
+const macroData = data.filter(d => areeMacro.includes(d.area));
+const cittaData = data.filter(d => citta.includes(d.area));
+
+const ultimoTrimestre = [...new Set(data.map(d => d.trimestre))].sort().pop();
+const ultimiValori = data.filter(d => d.trimestre === ultimoTrimestre);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Italia — ${ultimoTrimestre}</h3>
+    <span class="big">${ultimiValori.find(d => d.area === "Italy")?.indice_prezzi?.toFixed(1)}</span>
+  </div>
+  <div class="card">
+    <h3>Milano</h3>
+    <span class="big">${ultimiValori.find(d => d.area === "Milano")?.indice_prezzi?.toFixed(1)}</span>
+  </div>
+  <div class="card">
+    <h3>Mezzogiorno</h3>
+    <span class="big">${ultimiValori.find(d => d.area === "Mezzogiorno")?.indice_prezzi?.toFixed(1)}</span>
+  </div>
+</div>
+
+---
+
+## Andamento prezzi per macro-area
+
+Il divario Nord-Sud emerge chiaramente: mentre il Nord-ovest e il Nord-est superano la media nazionale, il Mezzogiorno resta stabilmente sotto. Milano viaggia ben distante da tutte.
+
+```js
+Plot.plot({
+  title: "Indice IPAB per macro-area — 2010–2025",
+  width: 800,
+  height: 400,
+  y: {grid: true, label: "indice (base 2010=100)"},
+  color: {legend: true},
+  marks: [
+    Plot.line(macroData, {
+      x: "trimestre",
+      y: "indice_prezzi",
+      z: "area",
+      stroke: "area",
+      tip: true
+    }),
+    Plot.ruleY([100])
+  ]
+})
+```
+
+---
+
+## Prezzi nelle grandi città
+
+Milano si distacca nettamente da Roma e Torino, con un indice che sfiora 180 — quasi l'80% in più rispetto al 2010.
+
+```js
+Plot.plot({
+  title: "Indice IPAB — Milano, Roma, Torino",
+  width: 800,
+  height: 350,
+  y: {grid: true, label: "indice (base 2010=100)"},
+  color: {legend: true, scheme: "Set1"},
+  marks: [
+    Plot.line(cittaData, {
+      x: "trimestre",
+      y: "indice_prezzi",
+      z: "area",
+      stroke: "area",
+      tip: true
+    }),
+    Plot.ruleY([100])
+  ]
+})
+```
+
+---
+
+## Ultimo trimestre — tutte le aree
+
+```js
+Inputs.table(ultimiValori, {
+  columns: ["area", "indice_prezzi"],
+  header: {area: "Area", indice_prezzi: "Indice prezzi"},
+  format: {indice_prezzi: x => x.toFixed(1)},
+  sort: "area",
+  rows: 10,
+  width: "100%"
+})
+```
+
+---
+
+## Risorse
+
+- [ISTAT — IPAB](https://www.istat.it/it/archivio/16773)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-ipab-aree)

--- a/src/dataset/istat-ipab-aree.md
+++ b/src/dataset/istat-ipab-aree.md
@@ -1,8 +1,11 @@
 ---
 title: Indice prezzi abitazioni (IPAB) per area
-description: Dati ISTAT sull'indice dei prezzi delle abitazioni (IPAB) per area geografica, trimestre e tipologia
+description: Dati ISTAT sull'indice dei prezzi delle abitazioni (IPAB) per area geografica e trimestre, 2010-2025
 source: ISTAT
-last_modified: 2025-12-31
+source_url: https://www.istat.it/it/archivio/16773
+period: "2010–2025"
+last_modified: 2026-05-26
+dataset_slug: istat_ipab_aree
 ---
 
 # Indice prezzi abitazioni (IPAB) per area
@@ -110,8 +113,19 @@ Inputs.table(ultimiValori, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2010-2025. Dati precedenti non sono disponibili in questo dataset.
+- **Indice base**: l'indice è calcolato con base 2010=100. Le variazioni percentuali sono relative al 2010, non all'anno precedente.
+- **Tipologia**: i dati si riferiscono a abitazioni esistenti (EXST_DW). Non include abitazioni nuove o di nuova costruzione.
+- **Aree**: la disaggregazione include macro-aree ISTAT e tre città (Milano, Roma, Torino). Non sono disponibili dati comunali o provinciali.
+
+---
+
 ## Risorse
 
-- [ISTAT — IPAB](https://www.istat.it/it/archivio/16773)
-- [Scarica il parquet pulito (2024)](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
+- [ISTAT — IPAB (fonte originale)](https://www.istat.it/it/archivio/16773)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-ipab-aree)

--- a/src/temi/welfare-lavoro.md
+++ b/src/temi/welfare-lavoro.md
@@ -1,11 +1,11 @@
 ---
 title: Welfare e lavoro
-description: Pubblico impiego, pensioni e previdenza
+description: Pubblico impiego, pensioni, previdenza e prezzi delle abitazioni
 ---
 
 # Welfare e lavoro
 
-Dipendenti pubblici per comparto e pensioni INPS per gestione previdenziale. I dataset di questo tema coprono il lavoro pubblico e la previdenza in Italia.
+Dipendenti pubblici, pensioni INPS e indice dei prezzi delle abitazioni per area geografica. I dataset di questo tema coprono il lavoro pubblico, la previdenza e il mercato immobiliare in Italia.
 
 ```js
 const catalog = await FileAttachment("../data/catalog.json").json();


### PR DESCRIPTION
## Cosa

Pagina dataset per **ISTAT IPAB Aree** — indice dei prezzi delle abitazioni per area geografica.

Closes #95.

### File creati

| File | Ruolo |
|------|-------|
| `src/data/istat-ipab-aree.json.py` | Loader: indice per area e trimestre |
| `src/dataset/istat-ipab-aree.md` | Pagina con 2 line chart + tabella |

### File modificati

- `observablehq.config.js` — registrata pagina `/dataset/istat-ipab-aree`
- `src/data/themes.json.py` — aggiunto a **Welfare e lavoro**
- `src/temi/welfare-lavoro.md` — link IPAB + descrizione aggiornata

### Struttura pagina

1. KPI card: Italia, Milano, Mezzogiorno (ultimo trimestre 2025-Q4)
2. Line chart: andamento macro-aree 2010–2025
3. Line chart: Milano vs Roma vs Torino
4. Tabella: tutte le aree nell'ultimo trimestre
5. Risorse e link parquet

### Dati

- 8 aree (Italia, 4 macro-aree, 3 città), 64 trimestri (2010-2025)
- Milano guida con indice 177.8, Mezzogiorno fanalino a 107.1
