### PR TITLE
feat: PR template e config per data-explorer

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,0 @@
-blank_issues_enabled: true
-contact_links:
-  - name: Discussioni e orientamento
-    url: https://github.com/orgs/dataciviclab/discussions
-    about: Per domande, idee e confronto iniziale usa le Discussions dell'organizzazione.
-  - name: Dataset pronti per explorer
-    url: https://github.com/dataciviclab/dataset-incubator/blob/main/registry/clean_catalog.json
-    about: Consulta il catalogo dei dataset disponibili prima di proporne uno nuovo.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussioni e orientamento
+    url: https://github.com/orgs/dataciviclab/discussions
+    about: Per domande, idee e confronto iniziale usa le Discussions dell'organizzazione.
+  - name: Dataset pronti per explorer
+    url: https://github.com/dataciviclab/dataset-incubator/blob/main/registry/clean_catalog.json
+    about: Consulta il catalogo dei dataset disponibili prima di proporne uno nuovo.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+## Sintesi
+
+Descrivi in poche righe cosa cambia e perché.
+
+## Contesto collegato
+
+Closes #
+
+## Cosa cambia
+
+- [ ] Nuovo dataset — pagina explorer
+- [ ] Bug fix frontend (data loader / layout / performance)
+- [ ] Aggiornamento config / catalogo
+- [ ] Modifica struttura dati upstream
+- [ ] Documentazione
+- [ ] Dipendenze o CI
+
+## Checklist nuovo dataset
+
+Se la PR aggiunge un nuovo dataset in explorer:
+
+- [ ] **Data loader**: `src/data/<slug-url>.json.py` creato
+- [ ] **Pagina**: `src/dataset/<slug-url>.md` creata
+- [ ] **Registrazione**: voce aggiunta in `observablehq.config.js` sezione `pages`
+- [ ] **Tema**: aggiornato `src/data/themes.json.py` (se nuovo tema)
+- [ ] **Verifica locale**: `npm run dev` — pagina navigabile, dati caricati
+- [ ] **Slug consistenti**: slug URL (trattini) e slug DI (underscore) allineati
+- [ ] **Leggibilità**: pagina leggibile da un utente non tecnico
+- [ ] **Clean catalog**: il dataset è presente in `clean_catalog.json` DI
+
+## Verifica
+
+Spiega come hai verificato il cambiamento.
+
+```bash
+npm run dev
+```
+
+- [ ] `npm run dev` produce output sensati
+- [ ] Data loader non solleva errori
+- [ ] Pagina si carica senza warning in console
+
+## Checklist PR
+
+- [ ] Perimetro stretto: una PR = un dataset o un fix mirato
+- [ ] Issue collegata o motivazione dell'assenza
+
+## Note per chi revisiona
+
+Rischi, limiti, punti da controllare con attenzione.


### PR DESCRIPTION
## Sintesi

Aggiunge PR template e config.yml a data-explorer, che finora usava solo i template generici dell'org `.github`.

## Cosa cambia

| File | Descrizione |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | PR template con checklist specifica per nuovo dataset: data loader, pagina md, registro config, tema, verifica `npm run dev`, leggibilità, slug consistenti |
| `.github/ISSUE_TEMPLATE/config.yml` | Link a Discussions e a `clean_catalog.json` per consultare dataset già pronti |

## Perché

- data-explorer ha una procedura PR specifica per aggiungere dataset (5 step nel CONTRIBUTING) che il template org generico non catturava
- Il config.yml indirizza i contributor a controllare il catalogo esistente prima di proporre un nuovo dataset

## Verifica

- I template sono solo file statici, nessun codice modificato
