### PR TITLE
docs: standard pagina dataset — template, CONTRIBUTING, README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,18 +35,25 @@ Apri http://localhost:3000
    - il nome del file usa slug URL con trattini (es. `bdap-lea-regioni.json.py`)
    - lo slug DI (con underscore, es. `bdap_lea`) va come parametro `slug=` a `load_dataset()`
    - vedi `src/data/_util.py` e i loader esistenti come riferimento
-2. **Pagina**: crea `src/dataset/<slug-url>.md`
-   - segui la struttura definita in `docs/dataset-page-standard.md`
-   - i data loader sono referenziati come `FileAttachment("../data/<nome>.json")`
+2. **Pagina**: copia il [template `docs/TEMPLATE-dataset-page.md`](docs/TEMPLATE-dataset-page.md)
+   in `src/dataset/<slug-url>.md` e compila ogni sezione
+   - frontmatter obbligatorio: `title`, `description`, `source`, `source_url`, `period`,
+     `last_modified`, `dataset_slug`
+   - primo blocco: distribuzione o stock base, non ranking o delta
+   - sezione **Limiti** obbligatoria in fondo (copertura, granularità, note metodologiche)
+   - vedi `docs/dataset-page-standard.md` per i principi guida
 3. **Registra** la pagina in `observablehq.config.js` nella sezione `pages`
 4. **Tema**: se il dataset introduce un nuovo tema, aggiungilo in `src/data/themes.json.py`
 5. **Verifica** con `npm run dev` che la pagina sia navigabile e i dati si carichino
+6. **Checklist pre-pub** (nel template, in fondo): verificare slug, parquet, frontmatter,
+   leggibilità, link funzionanti
 
 ## Standard e criteri
 
 Prima di proporre una nuova pagina, controlla:
 - [`docs/explorer-ready-checklist.md`](docs/explorer-ready-checklist.md) — classi di readiness
-- [`docs/dataset-page-standard.md`](docs/dataset-page-standard.md) — struttura standard della pagina
+- [`docs/dataset-page-standard.md`](docs/dataset-page-standard.md) — principi guida della pagina
+- [`docs/TEMPLATE-dataset-page.md`](docs/TEMPLATE-dataset-page.md) — template operativo
 
 Il principio guida: *nel Data Explorer entrano prima i dataset che si leggono bene, non quelli semplicemente disponibili.*
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,12 @@ Apri http://localhost:3000
 ## Documentazione
 
 - [`docs/explorer-ready-checklist.md`](docs/explorer-ready-checklist.md) — criteri per pubblicare un dataset nel catalogo
-- [`docs/dataset-page-standard.md`](docs/dataset-page-standard.md) — struttura standard di una pagina dataset
+- [`docs/dataset-page-standard.md`](docs/dataset-page-standard.md) — principi guida di una pagina dataset
+- [`docs/TEMPLATE-dataset-page.md`](docs/TEMPLATE-dataset-page.md) — template operativo per nuove pagine
 
 ## Pagine
 
-| Pagina | Dataset |
-|---|---|
-| Home | Catalogo completo dei dataset |
-| IRPEF comunale | Capacità fiscale per comune e regione |
-| Rifiuti urbani | Produzione e raccolta differenziata |
-| Flussi giustizia civile | Sopravvenuti, definiti e pendenti |
-| Dipendenti pubblici | Pubblico impiego per comparto |
-| Capacità rinnovabile | Potenza installata Terna |
-| Spesa farmaceutica | AIFA spesa e consumo SSN |
-| Entrate dello Stato | Previsioni BDAP RGS |
-| Pensioni INPS | Numero pensioni per gestione |
+Il catalogo completo è sulla [home page live](https://explorer.dataciviclab.org). Al momento sono pubblicati 13 dataset su 5 temi.
 
 ## Data loader
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Apri http://localhost:3000
 
 ## Pagine
 
-Il catalogo completo è sulla [home page live](https://explorer.dataciviclab.org). Al momento sono pubblicati 13 dataset su 5 temi.
+Il catalogo completo è sulla [home page live](https://explorer.dataciviclab.org), organizzato per temi e stato di pubblicazione.
 
 ## Data loader
 

--- a/docs/TEMPLATE-dataset-page.md
+++ b/docs/TEMPLATE-dataset-page.md
@@ -1,0 +1,155 @@
+---
+# Template pagina dataset — DataCivicLab Explorer
+# Copia in src/dataset/{slug}.md e compila ogni sezione.
+# I principi guida: docs/dataset-page-standard.md
+# La procedura completa: CONTRIBUTING.md → "Aggiungere una pagina dataset"
+#
+# FRONTMATTER — tutto obbligatorio
+title: Nome leggibile del dataset
+description: Una frase che dice cosa contiene e perché è utile (max 150 caratteri)
+source: Ente che pubblica il dato originale (es. "ISTAT", "MEF — Dipartimento delle Finanze")
+source_url: URL della fonte originale
+period: "YYYY–YYYY"  # intervallo di anni coperto dal dataset
+last_modified: YYYY-MM-DD  # data dell'ultimo aggiornamento del parquet pulito
+dataset_slug: slug_del_dataset_su_gcs  # slug DI (con underscore) per data loader
+---
+
+# Nome leggibile del dataset
+
+**Una frase** che spiega cosa c'è dentro, a che livello di dettaglio e qual è il periodo coperto.
+
+**Fonte**: [Nome ente](URL) · **Periodo**: {period}
+
+<!--
+  DATA LOADER
+  Riferisci i JSON prodotti dal loader in src/data/
+  Naming: {slug-url}.json per loader principale, {slug-url}-{vista}.json per loader specifici
+-->
+```js
+const data = await FileAttachment("../data/{slug-url}.json").json();
+```
+
+<!--
+  SE SERVE UN SECONDO LOADER (es. per regione/dettaglio)
+-->
+```js
+// const secondData = await FileAttachment("../data/{slug-url}-second.json").json();
+```
+
+```js
+// Filtri standard
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+```
+
+```js
+// Preparazione dati filtrati
+const filtered = data.filter(d => d.anno === annoSel);
+// + metriche riassuntive
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Metrica 1</h3>
+    <span class="big">{valore}</span>
+  </div>
+  <div class="card">
+    <h3>Metrica 2</h3>
+    <span class="big">{valore}</span>
+  </div>
+  <div class="card">
+    <h3>Metrica 3</h3>
+    <span class="big">{valore}</span>
+  </div>
+</div>
+
+---
+
+## Blocco principale — distribuzione base
+
+<!--
+  PRIMO BLOCCO: mostra il dataset nella sua forma più naturale.
+  Deve rispondere alla domanda guida della pagina.
+  Deve essere uno solo.
+  Deve mostrare STOCK / DISTRIBUZIONE / COMPOSIZIONE base, non delta o trend.
+-->
+
+Breve nota di lettura (max 2 righe). Cosa mostra questo grafico? Come leggerlo?
+
+```js
+Plot.plot({
+  // grafico: barre, mappa o charts che mostrano la distribuzione base
+})
+```
+
+> **Nota**: se serve, nota breve su perimetro o metrica.
+
+---
+
+## Blocco secondario — confronto o dettaglio
+
+<!--
+  SECONDO BLOCCO: confronto, delta, trend, o vista alternativa.
+  Deve essere diverso dal primo, non una ripetizione.
+-->
+
+Breve nota su cosa mostra questo secondo blocco.
+
+```js
+Plot.plot({
+  // secondo grafico o tabella
+})
+```
+
+---
+
+## Dettaglio
+
+<!--
+  TABELLA FINALE: vista completa, ricercabile e scaricabile.
+  Default consigliato per v0.
+-->
+
+```js
+Inputs.table(filtered, {
+  columns: ["col1", "col2", "col3"],
+  header: {col1: "Nome leggibile", col2: "Nome leggibile", col3: "Nome leggibile"},
+  format: { /* formattazione valori */ },
+  rows: 20,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+<!--
+  SEZIONE OBBLIGATORIA. Elenca cosa il dataset NON permette di dire.
+  Tre punti massimi, linguaggio pubblico.
+-->
+- **Copertura**: il dataset copre {periodo}, non sono disponibili dati precedenti
+- **Granularità**: i dati sono aggregati per {livello}, non è possibile scendere a dettaglio {X}
+- **Nota metodologica**: {eventuale caveat sul significato delle metriche, doppi conteggi, cambi di classificazione}
+- **Aggiornamento**: l'ultimo aggiornamento risale al {data}, i dati potrebbero non riflettere l'anno in corso
+
+---
+
+## Risorse
+
+- [Fonte originale]({source_url})
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/{slug_gcs}/{anno}/{slug_gcs}_{anno}_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/{slug_candidate})
+- [Analisi collegate](/analisi/{slug-analisi}) <!-- se esistono -->
+
+<!--
+  CHECKLIST PRE-PUBBLICAZIONE
+  [ ] Slug DE e slug DI coincidono
+  [ ] Clean parquet pubblico esiste su GCS
+  [ ] Data loader funziona (npm run dev)
+  [ ] Frontmatter completo (title, description, source, source_url, period, last_modified, dataset_slug)
+  [ ] Primo blocco mostra stock/distribuzione base, non delta o trend
+  [ ] Sezione Limiti compilata
+  [ ] Link a fonte originale e parquet funzionanti
+  [ ] Pagina leggibile da un utente non tecnico
+-->

--- a/docs/dataset-page-standard.md
+++ b/docs/dataset-page-standard.md
@@ -1,6 +1,7 @@
 # Standard Pagina Dataset
 
-Questo documento definisce la forma minima di una buona pagina dataset nel `Data Explorer`.
+Questo documento definisce i **principi** di una buona pagina dataset nel `Data Explorer`.
+Per il **template operativo** da copiare, vedi [`TEMPLATE-dataset-page.md`](TEMPLATE-dataset-page.md).
 
 ## Obiettivo
 


### PR DESCRIPTION
## Sintesi

Standardizzazione del processo di creazione pagine dataset: template operativo, frontmatter obbligatorio, sezione Limiti, aggiornamento CONTRIBUTING e README.

## Cosa cambia

- [x] Documentazione

## Dettaglio

| File | Cosa |
|---|---|
| `docs/TEMPLATE-dataset-page.md` | **Nuovo** — template da copiare per ogni nuova pagina dataset |
| `CONTRIBUTING.md` | Passaggi più precisi: frontmatter obbligatorio, primo blocco stock, sezione Limiti, checklist pre-pub |
| `README.md` | Link al template + tabella pagine fissa → link al catalogo live |
| `docs/dataset-page-standard.md` | Link al template in testa |

### Cosa prevede il template

- Frontmatter obbligatorio: `title`, `description`, `source`, `source_url`, `period`, `last_modified`, `dataset_slug`
- Primo blocco: distribuzione/stock base dell'anno più recente (non ranking o delta)
- Sezione **Limiti** obbligatoria in fondo
- Checklist pre-pub nei commenti finali

### Cosa non cambia

- I principi guida di `dataset-page-standard.md` restano invariati
- I data loader Python restano manuali
- Le pagine esistenti **non** sono state riscritte (saranno allineate progressivamente)

## Verifica

Solo documentazione. Verifica visiva dei file.

## Checklist PR

- [x] Perimetro stretto: documentazione, nessun codice toccato
