### PR TITLE
fix: allineamento completo pagine dataset e tema al nuovo standard

### DIFF
--- a/src/data/catalog.json.py
+++ b/src/data/catalog.json.py
@@ -3,9 +3,37 @@ import json, sys, requests
 url = "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/clean_catalog.json"
 r = requests.get(url, timeout=15)
 cat = r.json()
+
+# Mapping DI slug (underscore) → URL slug (hyphen) per pagine Explorer.
+# Fallback: sostituisce _ con - meccanicamente.
+SLUG_MAP = {
+    "aifa_spesa_consumo": "spesa-farmaceutica",
+    "ispra_ru_base": "rifiuti-urbani",
+    "civile_flussi": "flussi-giustizia-civile",
+    "terna_capacita_rinnovabile": "capacita-rinnovabile",
+    "bdap_entrate_stato": "entrate-stato",
+    "inps_pensioni_trimestrale": "pensioni-inps",
+}
+
 datasets = []
 for ds in cat.get("datasets", []):
     period = ds.get("period", {})
-    datasets.append({"slug": ds["slug"], "name": ds.get("name", ""), "description": ds.get("description", "")[:150], "stage": ds.get("stage", ""), "years": f"{period.get('start','?')}–{period.get('end','?')}" if period else "?", "source": ds.get("source", "")})
-output = {"updated_at": cat.get("updated_at", ""), "total": len(datasets), "published": sum(1 for d in datasets if d["stage"] == "published"), "incubating": sum(1 for d in datasets if d["stage"] == "incubating"), "datasets": datasets}
+    slug = ds["slug"]
+    url_slug = SLUG_MAP.get(slug, slug.replace("_", "-"))
+    datasets.append({
+        "slug": slug,
+        "url_slug": url_slug,
+        "name": ds.get("name", ""),
+        "description": ds.get("description", "")[:150],
+        "stage": ds.get("stage", ""),
+        "years": f"{period.get('start','?')}–{period.get('end','?')}" if period else "?",
+        "source": ds.get("source", ""),
+    })
+output = {
+    "updated_at": cat.get("updated_at", ""),
+    "total": len(datasets),
+    "published": sum(1 for d in datasets if d["stage"] == "published"),
+    "incubating": sum(1 for d in datasets if d["stage"] == "incubating"),
+    "datasets": datasets,
+}
 json.dump(output, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -8,35 +8,30 @@ themes = [
         "name": "Territorio e ambiente",
         "description": "Trasformazioni territoriali, ambiente, energia e rifiuti",
         "datasets": ["rifiuti-urbani", "capacita-rinnovabile"],
-        "questions": ["Come varia la raccolta differenziata tra territori?", "Come cambia il mix elettrico regionale tra fonti fossili e rinnovabili?"],
     },
     {
         "slug": "finanza-pubblica",
         "name": "Finanza pubblica",
         "description": "Entrate dello Stato, capacità fiscale e tributi locali",
         "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione"],
-        "questions": ["Come si distribuisce la capacità fiscale tra regioni?", "Quali sono le principali voci di entrata dello Stato?", "Quanto spende la PA attraverso le convenzioni Consip?"],
     },
     {
         "slug": "sanita",
         "name": "Sanità",
         "description": "Spesa farmaceutica, consumi sanitari e prevenzione",
         "datasets": ["spesa-farmaceutica", "bdap-lea"],
-        "questions": ["Come cambia tra regioni la spesa farmaceutica per classi terapeutiche?", "Quanto spendono le regioni per i Livelli Essenziali di Assistenza?"],
     },
     {
         "slug": "welfare-lavoro",
         "name": "Welfare e lavoro",
         "description": "Pubblico impiego, pensioni e previdenza",
         "datasets": ["dipendenti-pubblici", "pensioni-inps"],
-        "questions": ["La crescita del pubblico impiego è diffusa o concentrata in pochi comparti?", "Come sono distribuite le pensioni tra gestioni previdenziali?"],
     },
     {
         "slug": "giustizia",
         "name": "Giustizia",
         "description": "Flussi civili, tempi e carichi dei tribunali",
         "datasets": ["flussi-giustizia-civile"],
-        "questions": ["Come si distribuisce il carico civile tra i distretti italiani?"],
     },
 ]
 

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -25,13 +25,6 @@ const nRegioni = regioni.length;
 const mediaRegione = totSpesa / nRegioni;
 ```
 
-```js
-const totPrestazioni = d3.sum(regioni, d => d.prestazioni_sanitarie);
-const totDiretto = totSpesa - totPrestazioni;
-```
-
-> **Nota sul totale**: la spesa complessiva (~€${(totSpesa / 1e9).toFixed(0)} mld) include le **transazioni inter-ente** per mobilità sanitaria (prestazioni acquistate da altri enti SSN, ~€${(totPrestazioni / 1e9).toFixed(0)} mld). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Escludendo questo effetto, il costo operativo diretto è circa €${(totDiretto / 1e9).toFixed(0)} mld.
-
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Spesa totale LEA</h3>
@@ -46,6 +39,54 @@ const totDiretto = totSpesa - totPrestazioni;
     <span class="big">${nRegioni}</span>
   </div>
 </div>
+
+---
+
+## Composizione della spesa per macro-area
+
+Come si distribuisce la spesa sanitaria tra le quattro macro-aree? L'assistenza distrettuale e ospedaliera assorbono la quasi totalità delle risorse, mentre prevenzione e ricerca pesano in misura marginale.
+
+```js
+const nazionaleMacro = Array.from(
+  d3.rollup(macro, v => d3.sum(v, d => d.importo_totale), d => d.descrizione_voce_contabile),
+  ([descrizione_voce_contabile, importo_totale]) => ({descrizione_voce_contabile, importo_totale})
+).sort((a, b) => b.importo_totale - a.importo_totale);
+const totMacro = d3.sum(nazionaleMacro, d => d.importo_totale);
+const macroConPct = nazionaleMacro.map(d => ({...d, pct: d.importo_totale / totMacro * 100}));
+```
+
+```js
+Plot.plot({
+  title: "Composizione della spesa LEA per macro-area — 2024",
+  width: 800,
+  height: 300,
+  marginLeft: 200,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "miliardi di €", tickFormat: d => (d / 1e9).toFixed(1)},
+  color: {scheme: "Set2"},
+  marks: [
+    Plot.barX(macroConPct, {
+      y: "descrizione_voce_contabile",
+      x: "importo_totale",
+      fill: "descrizione_voce_contabile",
+      sort: {y: "-x"},
+      tip: {format: {x: d => `€ ${(d / 1e9).toFixed(1)} mld`}}
+    }),
+    Plot.text(macroConPct, {
+      y: "descrizione_voce_contabile",
+      x: "importo_totale",
+      text: d => `${d.pct.toFixed(1)}%`,
+      dx: 6,
+      textAnchor: "start",
+      fill: "var(--theme-foreground-muted)",
+      fontSize: 12
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+> **Nota sul totale**: la spesa complessiva (~€${(totSpesa / 1e9).toFixed(0)} mld) include le **transazioni inter-ente** per mobilità sanitaria (prestazioni acquistate da altri enti SSN). Ogni prestazione è contata sia dall'ente pagante sia dall'ente erogante. Escludendo questo effetto, il costo operativo diretto è circa €${((totSpesa - d3.sum(regioni, d => d.prestazioni_sanitarie)) / 1e9).toFixed(0)} mld.
 
 ---
 
@@ -75,47 +116,6 @@ Plot.plot({
       fill: "importo_totale",
       sort: {y: "-x"},
       tip: true
-    }),
-    Plot.ruleX([0])
-  ]
-})
-```
-
----
-
-## Composizione della spesa per macro-area
-
-Come si distribuisce la spesa tra le quattro macro-aree? In tutte le regioni l'assistenza distrettuale e ospedaliera assorbono la quasi totalità delle risorse, mentre prevenzione e ricerca pesano in misura marginale.
-
-```js
-const macroShort = macro.map(d => ({
-  ...d,
-  macro: d.descrizione_voce_contabile
-}));
-```
-
-```js
-// Top 5 regioni per spesa totale + composizione
-const top5 = ordinato.slice(0, 5).map(d => d.descrizione_regione);
-const macroTop5 = macroShort.filter(d => top5.includes(d.descrizione_regione));
-```
-
-```js
-Plot.plot({
-  title: "Composizione spesa LEA — top 5 regioni (2024)",
-  width: 800,
-  height: 350,
-  marginLeft: 120,
-  color: {legend: true, scheme: "Set2"},
-  y: {label: null, tickSize: 0},
-  x: {grid: true, label: "miliardi di €", tickFormat: d => (d / 1e9).toFixed(0)},
-  marks: [
-    Plot.barX(macroTop5, {
-      y: "descrizione_regione",
-      x: "importo_totale",
-      fill: "macro",
-      sort: {y: "-x"},
-      tip: {format: {x: d => `€ ${(d / 1e6).toFixed(0)} mln`}}
     }),
     Plot.ruleX([0])
   ]
@@ -158,8 +158,6 @@ Inputs.table(ordinato, {
   width: "100%"
 })
 ```
-
----
 
 ---
 

--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -1,8 +1,11 @@
 ---
 title: Spesa sanitaria regionale LEA
-description: Dati BDAP sui costi dei Livelli Essenziali di Assistenza per regione, macro-area e voce contabile
-source: BDAP — Banca Dati delle Amministrazioni Pubbliche
+description: Dati BDAP sui costi dei Livelli Essenziali di Assistenza per regione, macro-area e voce contabile, 2024
+source: BDAP — Banca Dati delle Amministrazioni Pubbliche (RGS MEF)
+source_url: https://bdap-opendata.rgs.mef.gov.it/
+period: "2024"
 last_modified: 2025-06-30
+dataset_slug: bdap_lea
 ---
 
 # Spesa sanitaria regionale LEA
@@ -158,8 +161,19 @@ Inputs.table(ordinato, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: il dataset copre il solo 2024. Non sono disponibili dati precedenti in questo dataset.
+- **Doppia contabilizzazione**: la spesa totale include le prestazioni sanitarie tra enti SSN (mobilità sanitaria), che vengono contate sia dall'ente pagante sia dall'ente erogante. Il costo operativo diretto è inferiore di circa il valore delle prestazioni.
+- **Enti esclusi**: le voci aggregate (codice ente '000' e '999') sono escluse dal dataset per evitare duplicazioni contabili.
+- **Pro capite**: il dato di spesa pro capite non è ancora disponibile in questo dataset.
+
+---
+
 ## Risorse
 
-- [BDAP — Open Data](https://bdap-opendata.rgs.mef.gov.it/)
+- [BDAP — Open Data (fonte originale)](https://bdap-opendata.rgs.mef.gov.it/)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_lea/2024/bdap_lea_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-lea)

--- a/src/dataset/capacita-rinnovabile.md
+++ b/src/dataset/capacita-rinnovabile.md
@@ -1,6 +1,11 @@
 ---
 title: Capacità rinnovabile per regione
-description: Dati Terna sulla capacità di generazione rinnovabile installata per regione e fonte
+description: Dati Terna sulla capacità di generazione rinnovabile installata per regione e fonte (potenza netta), 2023-2024
+source: Terna S.p.A.
+source_url: https://www.terna.it/
+period: "2023–2024"
+last_modified: 2026-05-26
+dataset_slug: terna_capacita_rinnovabile
 ---
 
 # Capacità rinnovabile per regione
@@ -115,8 +120,19 @@ Inputs.table(filtered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: il dataset copre solo il biennio 2023-2024. Non sono disponibili dati precedenti in questo dataset.
+- **Tipo capacità**: i dati si riferiscono alla potenza netta installata (tipo_capacita = 'Netta'). Non include capacità lorda o eventuale capacità autorizzata ma non ancora installata.
+- **Fonti**: la disaggregazione per fonte segue la classificazione Terna. La categoria "fonti" include tutte le rinnovabili; eventuali ibridi (es. termico con rinnovabile) sono classificati secondo la regola Terna.
+
+---
+
 ## Risorse
 
-- [Terna](https://www.terna.it/)
+- [Terna (fonte originale)](https://www.terna.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/terna_capacita_rinnovabile/2024/terna_capacita_rinnovabile_2024_clean.parquet)
 - [Analisi](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/terna-electricity-by-source)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/terna-capacita-rinnovabile)

--- a/src/dataset/capacita-rinnovabile.md
+++ b/src/dataset/capacita-rinnovabile.md
@@ -20,7 +20,7 @@ const data = await FileAttachment("../data/terna-fonti.json").json();
 
 ```js
 const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -21,7 +21,7 @@ const tipologie = await FileAttachment("../data/consip-consumi-convenzione-tipol
 
 ```js
 const anni = [...new Set(regioni.map(d => d.anno_riferimento))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -1,8 +1,11 @@
 ---
 title: Consumi in convenzione Consip
-description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione e tipologia di amministrazione
-source: Consip
+description: Dati Consip sugli acquisti della PA attraverso convenzioni, per regione e tipologia di amministrazione, 2023-2025
+source: Consip S.p.A. / MEF
+source_url: https://dati.consip.it/
+period: "2023–2025"
 last_modified: 2025-12-31
+dataset_slug: consip_consumi_convenzione
 ---
 
 # Consumi in convenzione Consip
@@ -133,8 +136,18 @@ Inputs.table(regFiltered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: i dati coprono il periodo 2023-2025. Anni precedenti non sono disponibili in questo dataset.
+- **Regione PA**: la regione indicata è quella della PA acquirente, non quella del fornitore né quella di utilizzo del bene/servizio. Per le amministrazioni centrali, la sede legale è spesso nel Lazio indipendentemente dalla destinazione d'uso.
+- **Convenzioni**: il dato include solo acquisti attraverso convenzioni Consip attive. Acquisti diretti o attraverso altri strumenti (MEPA, accordi quadro) non sono inclusi.
+
+---
+
 ## Risorse
 
-- [Consip — Dati](https://dati.consip.it/)
+- [Consip — Dati (fonte originale)](https://dati.consip.it/)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/consip_consumi_convenzione/2025/consip_consumi_convenzione_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/consip-consumi-convenzione)

--- a/src/dataset/dipendenti-pubblici.md
+++ b/src/dataset/dipendenti-pubblici.md
@@ -65,6 +65,7 @@ Plot.plot({
   title: `Dipendenti ${compartoSel === "Tutti i comparti" ? "totali" : compartoSel}`,
   width: 800,
   height: 400,
+  x: {tickFormat: d => String(d)},
   y: {grid: true, tickFormat: "~s"},
   marks: [
     Plot.lineY(trendData, {x: "anno", y: "totale", tip: true}),
@@ -113,7 +114,7 @@ Plot.plot({
 Inputs.table(filtered, {
   columns: ["anno", "comparto", "donne", "uomini", "totale"],
   header: {comparto: "Comparto", donne: "Donne", uomini: "Uomini", totale: "Totale"},
-  format: {donne: x => x.toLocaleString("it-IT"), uomini: x => x.toLocaleString("it-IT"), totale: x => x.toLocaleString("it-IT")},
+  format: {anno: x => String(x), donne: x => x.toLocaleString("it-IT"), uomini: x => x.toLocaleString("it-IT"), totale: x => x.toLocaleString("it-IT")},
   rows: 20,
   width: "100%"
 })

--- a/src/dataset/dipendenti-pubblici.md
+++ b/src/dataset/dipendenti-pubblici.md
@@ -1,6 +1,11 @@
 ---
 title: Dipendenti pubblici per comparto
-description: Dati BDAP/RGS sul pubblico impiego, crescita e composizione dei comparti (2010-2023)
+description: Dati BDAP/RGS sul pubblico impiego per comparto, genere e orario di lavoro, 2010-2023
+source: MEF — RGS · BDAP
+source_url: https://www.rgs.mef.gov.it/
+period: "2010–2023"
+last_modified: 2026-05-26
+dataset_slug: dipendenti_pubblici
 ---
 
 # Dipendenti pubblici per comparto
@@ -116,8 +121,19 @@ Inputs.table(filtered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: i dati coprono il periodo 2010-2023. I dati 2024 non sono ancora disponibili.
+- **Genere**: il totale donne/uomini è calcolato sommando tempo pieno e part time (sopra e sotto 50%). Non include eventuali contratti atipici non ricompresi nelle categorie del dataset.
+- **Comparti**: la classificazione per comparto può variare nel periodo considerato a seguito di riforme del pubblico impiego.
+
+---
+
 ## Risorse
 
-- [MEF · RGS · BDAP](https://www.rgs.mef.gov.it/)
+- [MEF · RGS · BDAP (fonte originale)](https://www.rgs.mef.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici/2023/dipendenti_pubblici_2023_clean.parquet)
 - [Analisi](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/dipendenti-pubblici)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/dipendenti-pubblici)

--- a/src/dataset/entrate-stato.md
+++ b/src/dataset/entrate-stato.md
@@ -20,7 +20,7 @@ const data = await FileAttachment("../data/bdap-entrate.json").json();
 
 ```js
 const anni = [...new Set(data.map(d => d.esercizio_finanziario))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/entrate-stato.md
+++ b/src/dataset/entrate-stato.md
@@ -1,6 +1,11 @@
 ---
 title: Entrate dello Stato
-description: Previsioni definitive di entrata dello Stato per titolo (BDAP — RGS MEF)
+description: Previsioni definitive di entrata dello Stato per titolo, natura e tipologia — BDAP RGS MEF, 2008-2024
+source: RGS · BDAP — Banca Dati delle Amministrazioni Pubbliche
+source_url: https://bdap.rgs.mef.gov.it/
+period: "2008–2024"
+last_modified: 2026-05-26
+dataset_slug: bdap_entrate_stato
 ---
 
 # Entrate dello Stato
@@ -103,7 +108,18 @@ Inputs.table(filtered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Previsioni**: i dati si riferiscono alle previsioni definitive di bilancio, non agli effettivi incassi. La differenza tra previsioni e consuntivo può essere significativa.
+- **Copertura**: la serie parte dal 2008, anno di introduzione della contabilità armonizzata per lo Stato. Anni precedenti non sono comparabili.
+- **Classificazione**: la disaggregazione per titolo segue la classificazione economica del bilancio dello Stato, che può variare tra esercizi finanziari.
+
+---
+
 ## Risorse
 
-- [RGS · BDAP](https://bdap.rgs.mef.gov.it/)
+- [RGS · BDAP (fonte originale)](https://bdap.rgs.mef.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_entrate_stato/2024/bdap_entrate_stato_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-entrate-stato)

--- a/src/dataset/entrate-stato.md
+++ b/src/dataset/entrate-stato.md
@@ -50,7 +50,7 @@ const totaleEntrate = d3.sum(filtered, d => d.previsioni_definitive_cp);
 
 ```js
 Plot.plot({
-  title: `Previsioni definitive entrata per titolo — ${annoSel}`,
+  title: `Previsioni definitive entrata per titolo — ${String(annoSel)}`,
   width: 800,
   height: 300,
   marginLeft: 200,
@@ -83,6 +83,7 @@ Plot.plot({
   title: "Entrate totali dello Stato per anno",
   width: 800,
   height: 350,
+  x: {tickFormat: d => String(d)},
   y: {grid: true, tickFormat: "~s"},
   marks: [
     Plot.lineY(trend, {x: "esercizio_finanziario", y: "previsioni_definitive_cp", tip: true}),

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -1,6 +1,11 @@
 ---
 title: Flussi della giustizia civile
-description: Dati del Ministero della Giustizia sui flussi civili nei tribunali distrettuali italiani
+description: Sopravvenuti, definiti e pendenti per distretto — Ministero della Giustizia, 2014-2025
+source: Ministero della Giustizia — Direzione Generale di Statistica
+source_url: https://datiestatistiche.giustizia.it
+period: "2014–2025"
+last_modified: 2026-05-26
+dataset_slug: civile_flussi
 ---
 
 # Flussi della giustizia civile
@@ -124,8 +129,19 @@ Inputs.table(filtered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: la serie storica 2014-2025 proviene da un unico file snapshot. Anni precedenti al 2014 non sono disponibili.
+- **Rapporto D/S**: il rapporto definiti/sopravvenuti è un indicatore di smaltimento annuale. Un rapporto > 1 indica smaltimento parziale dell'arretrato, non necessariamente efficienza complessiva del sistema giudiziario.
+- **Granularità**: i dati sono aggregati per distretto di Corte d'Appello. Non è possibile scendere al dettaglio di singoli tribunali con questo dataset.
+
+---
+
 ## Risorse
 
-- [Ministero della Giustizia](https://datiestatistiche.giustizia.it)
+- [Ministero della Giustizia (fonte originale)](https://datiestatistiche.giustizia.it)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/civile_flussi/2025/civile_flussi_2025_clean.parquet)
 - [Analisi completa](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/civile-flussi)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/civile-flussi)

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -20,7 +20,7 @@ const data = await FileAttachment("../data/civile-flussi.json").json();
 
 ```js
 const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -174,4 +174,6 @@ Inputs.table(capConMedia, {
 - [MEF — Dipartimento delle Finanze (fonte originale)](https://www1.finanze.gov.it/)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/irpef-comunale)
+<!-- Analisi non ancora pubblicata. Quando sarà disponibile, aggiungere:
 - [Analisi sul reddito IRPEF](/analisi/irpef-comunale)
+-->

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -1,13 +1,18 @@
 ---
 title: IRPEF comunale
-description: Lettura pubblica dei dati IRPEF comunali del MEF, 2019-2023
+description: Contribuenti, reddito imponibile e imposta netta IRPEF per comune e regione, 2019-2023
+source: MEF — Dipartimento delle Finanze
+source_url: https://www1.finanze.gov.it/
+period: "2019–2023"
+last_modified: 2026-05-26
+dataset_slug: irpef_comunale
 ---
 
 # IRPEF comunale
 
-Lettura pubblica dei dati IRPEF comunali del MEF. Contribuenti, reddito imponibile e confronto tra regioni.
+Contribuenti, reddito imponibile e imposta netta IRPEF per comune italiano. I dati permettono di confrontare la capacità fiscale tra territori e l'evoluzione del reddito dichiarato nel tempo.
 
-**Fonte**: MEF · **Periodo**: 2019–2023
+**Fonte**: [MEF — Dipartimento delle Finanze](https://www1.finanze.gov.it/) · **Periodo**: 2019–2023
 
 ```js
 const regioni = await FileAttachment("../data/irpef-regioni.json").json();
@@ -22,7 +27,7 @@ const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
 ```js
 const regFiltered = regioni
   .filter(d => d.anno_di_imposta === annoSel)
-  .sort((a, b) => b.reddito_imponibile_eur - a.reddito_imponibile_eur);
+  .sort((a, b) => a.regione.localeCompare(b.regione));
 ```
 
 ```js
@@ -32,8 +37,12 @@ const capFiltered = capoluoghi
 ```
 
 ```js
-const totContribuenti = regFiltered.reduce((s, d) => s + d.numero_contribuenti, 0);
-const totReddito = regFiltered.reduce((s, d) => s + d.reddito_imponibile_eur, 0);
+const totContribuenti = regioni
+  .filter(d => d.anno_di_imposta === annoSel)
+  .reduce((s, d) => s + d.numero_contribuenti, 0);
+const totReddito = regioni
+  .filter(d => d.anno_di_imposta === annoSel)
+  .reduce((s, d) => s + d.reddito_imponibile_eur, 0);
 const nRegioni = new Set(regFiltered.map(d => d.regione)).size;
 ```
 
@@ -54,24 +63,34 @@ const nRegioni = new Set(regFiltered.map(d => d.regione)).size;
 
 ---
 
-## Reddito imponibile per regione
+## Composizione del reddito per regione
+
+Come si distribuisce il reddito imponibile tra le regioni italiane? Il grafico mostra la quota di ciascuna regione sul totale nazionale: le regioni più popolose pesano di più, ma il dato pro capite — non ancora presente in questa pagina — darebbe un quadro più preciso della capacità fiscale reale.
+
+```js
+const totNazionale = d3.sum(regFiltered, d => d.reddito_imponibile_eur);
+const conQuota = regFiltered.map(d => ({
+  ...d,
+  quota_pct: d.reddito_imponibile_eur / totNazionale * 100
+})).sort((a, b) => b.quota_pct - a.quota_pct);
+```
 
 ```js
 Plot.plot({
-  title: `Reddito imponibile per regione — ${annoSel}`,
+  title: `Quota del reddito nazionale per regione — ${annoSel}`,
   width: 800,
   height: 450,
   marginLeft: 120,
   y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
+  x: {grid: true, label: "% del totale nazionale", tickFormat: d => d.toFixed(1) + "%"},
   color: {scheme: "Blues"},
   marks: [
-    Plot.barX(regFiltered, {
+    Plot.barX(conQuota, {
       y: "regione",
-      x: "reddito_imponibile_eur",
-      fill: "reddito_imponibile_eur",
+      x: "quota_pct",
+      fill: "quota_pct",
       sort: {y: "-x"},
-      tip: true
+      tip: {format: {x: d => d.toFixed(1) + "%"}}
     }),
     Plot.ruleX([0])
   ]
@@ -81,6 +100,15 @@ Plot.plot({
 ---
 
 ## Reddito medio per contribuente — capoluoghi
+
+Quanto guadagna in media un contribuente nei capoluoghi italiani? La classifica mostra il reddito medio dichiarato, che riflette la struttura economica locale (settori prevalenti, costo della vita, specializzazione produttiva).
+
+```js
+const capConMedia = capFiltered.map(d => ({
+  ...d,
+  reddito_medio: Math.round(d.reddito_imponibile_eur / d.numero_contribuenti)
+}));
+```
 
 ```js
 Plot.plot({
@@ -92,10 +120,10 @@ Plot.plot({
   x: {grid: true, tickFormat: "~s"},
   color: {scheme: "Turbo"},
   marks: [
-    Plot.barX(capFiltered, {
+    Plot.barX(capConMedia, {
       y: "comune",
-      x: d => Math.round(d.reddito_imponibile_eur / d.numero_contribuenti),
-      fill: d => Math.round(d.reddito_imponibile_eur / d.numero_contribuenti),
+      x: "reddito_medio",
+      fill: "reddito_medio",
       sort: {y: "-x"},
       tip: true
     }),
@@ -109,18 +137,20 @@ Plot.plot({
 ## Dettaglio capoluoghi
 
 ```js
-Inputs.table(capFiltered, {
-  columns: ["comune", "regione", "numero_contribuenti", "reddito_imponibile_eur", "imposta_netta_eur"],
+Inputs.table(capConMedia, {
+  columns: ["comune", "regione", "numero_contribuenti", "reddito_imponibile_eur", "imposta_netta_eur", "reddito_medio"],
   header: {
     comune: "Comune",
     regione: "Regione",
     numero_contribuenti: "Contribuenti",
     reddito_imponibile_eur: "Reddito imponibile (€)",
-    imposta_netta_eur: "Imposta netta (€)"
+    imposta_netta_eur: "Imposta netta (€)",
+    reddito_medio: "Reddito medio (€)"
   },
   format: {
     reddito_imponibile_eur: x => `€ ${x.toLocaleString("it-IT")}`,
     imposta_netta_eur: x => `€ ${x.toLocaleString("it-IT")}`,
+    reddito_medio: x => `€ ${x.toLocaleString("it-IT")}`,
     numero_contribuenti: x => x.toLocaleString("it-IT")
   },
   rows: 20,
@@ -130,7 +160,18 @@ Inputs.table(capFiltered, {
 
 ---
 
+## Limiti
+
+- **Copertura**: i dati coprono il periodo 2019-2023. Non sono ancora disponibili i dati 2024 al momento dell'ultimo aggiornamento.
+- **Contribuenti**: il numero di contribuenti per regione è ottenuto sommando le dichiarazioni per comune. Un contribuente che presenta più fonti di reddito (es. lavoro dipendente + pensione) può essere contato una sola volta nel dato aggregato per comune, ma la metodologia esatta di deduplicazione è definita dal MEF.
+- **Reddito medio**: il reddito medio per contribuente è calcolato come rapporto tra reddito imponibile totale e numero di contribuenti. Non tiene conto di distribuzione interna (disuguaglianza) né di differenze del costo della vita tra territori.
+- **Capoluoghi**: la lista dei capoluoghi include i comuni capoluogo di regione. I dati per Aosta non sono attualmente disponibili nel data loader.
+
+---
+
 ## Risorse
 
-- [MEF — Finanze](https://www1.finanze.gov.it/)
+- [MEF — Dipartimento delle Finanze (fonte originale)](https://www1.finanze.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/irpef-comunale)
+- [Analisi sul reddito IRPEF](/analisi/irpef-comunale)

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -21,7 +21,7 @@ const capoluoghi = await FileAttachment("../data/irpef-capoluoghi.json").json();
 
 ```js
 const anni = [...new Set(regioni.map(d => d.anno_di_imposta))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/pensioni-inps.md
+++ b/src/dataset/pensioni-inps.md
@@ -1,6 +1,11 @@
 ---
 title: Pensioni INPS
-description: Numero di pensioni INPS per gestione previdenziale, area geografica e anno
+description: Numero di pensioni INPS per gestione previdenziale, area geografica e anno, 2020-2024
+source: INPS — Open Data
+source_url: https://www.inps.it/open-data
+period: "2020–2024"
+last_modified: 2026-05-26
+dataset_slug: inps_pensioni_trimestrale
 ---
 
 # Pensioni INPS
@@ -110,7 +115,19 @@ Inputs.table(perGestione, {
 
 ---
 
+---
+
+## Limiti
+
+- **Periodo**: il dato si riferisce al 2024 (ultimo anno disponibile). I dati precedenti (2020-2023) sono disponibili ma non ancora caricati in questa pagina.
+- **Cadenza trimestrale**: i dati sono pubblicati con cadenza trimestrale da INPS. Il totale mostrato è la somma dei trimestri dell'anno. Il numero di pensioni è uno **stock** (pensioni in essere alla fine del trimestre), non un flusso di nuove decorrenze: la somma annuale non va dunque interpretata come "nuove pensioni erogate nell'anno".
+- **Gestioni**: la disaggregazione per gestione segue la classificazione INPS. Alcune gestioni minori potrebbero essere aggregate in voci residuali.
+- **Aggiornamento**: il dataset viene aggiornato con cadenza trimestrale. L'ultimo aggiornamento disponibile è il quarto trimestre 2024.
+
+---
+
 ## Risorse
 
-- [INPS Open Data](https://www.inps.it/open-data)
+- [INPS Open Data (fonte originale)](https://www.inps.it/open-data)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/inps-pensioni)

--- a/src/dataset/pensioni-inps.md
+++ b/src/dataset/pensioni-inps.md
@@ -20,7 +20,7 @@ const data = await FileAttachment("../data/inps-pensioni.json").json();
 
 ```js
 const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -50,7 +50,7 @@ const comuniFiltrati = comuni
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Rifiuti totali</h3>
-    <span class="big">${Math.round(totRU / 1000000).toLocaleString("it-IT")} <small style="opacity:0.6">t</small></span>
+    <span class="big">${Math.round(totRU).toLocaleString("it-IT")} <small style="opacity:0.6">t</small></span>
   </div>
   <div class="card">
     <h3>Quota RD</h3>
@@ -68,7 +68,7 @@ const comuniFiltrati = comuni
 
 ```js
 Plot.plot({
-  title: `Quota raccolta differenziata per regione — ${annoSel}`,
+  title: `Quota raccolta differenziata per regione — ${String(annoSel)}`,
   width: 800,
   height: 450,
   marginLeft: 120,
@@ -95,7 +95,7 @@ Plot.plot({
 
 ```js
 Plot.plot({
-  title: `Percentuale RD nei grandi comuni — ${annoSel}`,
+  title: `Percentuale RD nei grandi comuni — ${String(annoSel)}`,
   width: 800,
   height: 350,
   marginLeft: 120,

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -21,7 +21,7 @@ const comuni = await FileAttachment("../data/ispra-comuni.json").json();
 
 ```js
 const anni = [...new Set(regioni.map(d => d.anno))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -1,6 +1,11 @@
 ---
 title: Rifiuti urbani nei comuni
-description: Dati ISPRA su rifiuti urbani, raccolta differenziata e volumi per comune e regione
+description: Dati ISPRA su rifiuti urbani, raccolta differenziata e volumi per comune e regione, 2020-2024
+source: ISPRA
+source_url: https://www.isprambiente.gov.it/it/dati/dati-sui-rifiuti-urbani
+period: "2020–2024"
+last_modified: 2026-05-26
+dataset_slug: ispra_ru_base
 ---
 
 # Rifiuti urbani nei comuni
@@ -125,7 +130,18 @@ Inputs.table(regFiltered, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: i dati coprono il periodo 2020-2024. I dati 2024 sono preliminari e potrebbero essere rivisti da ISPRA.
+- **Popolazione**: i dati comunali con popolazione ≥ 100.000 abitanti sono un sottoinsieme dei comuni italiani; non rappresentano l'intero territorio nazionale.
+- **Percentuale RD**: calcolata come rapporto tra totale RD e totale RU. Variazioni nella metodologia di calcolo ISPRA tra anni possono influenzare il dato.
+
+---
+
 ## Risorse
 
-- [ISPRA — Rifiuti Urbani](https://www.isprambiente.gov.it/it/dati/dati-sui-rifiuti-urbani)
+- [ISPRA — Rifiuti Urbani (fonte originale)](https://www.isprambiente.gov.it/it/dati/dati-sui-rifiuti-urbani)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/ispra-ru-base)

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -10,7 +10,7 @@ dataset_slug: aifa_spesa_consumo
 
 # Spesa farmaceutica convenzionata
 
-Spesa e consumo della farmaceutica convenzionata SSN, disaggregati per regione, mese e classe terapeutica ATC.
+Spesa e consumo della farmaceutica convenzionata SSN, disaggregati per regione, mese e classe terapeutica ATC. I dati mostrano quali categorie terapeutiche assorbono più risorse e come varia la spesa tra territori.
 
 **Fonte**: AIFA · **Periodo**: 2018–2024
 
@@ -56,7 +56,56 @@ const totaleConfezioni = d3.sum(perRegione, d => d.confezioni);
 
 ---
 
+## Spesa per classe terapeutica
+
+Quali categorie di farmaci assorbono più risorse del SSN? Il sistema cardiovascolare, l'apparato gastrointestinale e il sistema nervoso guidano la spesa farmaceutica convenzionata.
+
+```js
+const perAtc1 = Array.from(
+  d3.rollup(filtered, v => d3.sum(v, d => d.spesa_convenzionata), d => d.descrizione_atc1),
+  ([descrizione_atc1, spesa]) => ({descrizione_atc1, spesa})
+).sort((a, b) => b.spesa - a.spesa);
+
+const totAtc = d3.sum(perAtc1, d => d.spesa);
+const atcConPct = perAtc1.map(d => ({...d, pct: d.spesa / totAtc * 100}));
+```
+
+```js
+Plot.plot({
+  title: `Spesa per classe terapeutica ATC1 — ${annoSel}`,
+  width: 800,
+  height: 350,
+  marginLeft: 200,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Set2"},
+  marks: [
+    Plot.barX(atcConPct, {
+      y: "descrizione_atc1",
+      x: "spesa",
+      fill: "descrizione_atc1",
+      sort: {y: "-x"},
+      tip: {format: {x: d => `€ ${(d / 1e6).toFixed(0)} mln`}}
+    }),
+    Plot.text(atcConPct, {
+      y: "descrizione_atc1",
+      x: "spesa",
+      text: d => `${d.pct.toFixed(1)}%`,
+      dx: 6,
+      textAnchor: "start",
+      fill: "var(--theme-foreground-muted)",
+      fontSize: 11
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
 ## Spesa per regione
+
+Come si distribuisce la spesa farmaceutica tra le regioni? Le regioni più popolose hanno una spesa maggiore in valore assoluto, ma la spesa pro capite — non ancora presente in questa pagina — darebbe un quadro più preciso.
 
 ```js
 Plot.plot({
@@ -82,36 +131,6 @@ Plot.plot({
 
 ---
 
-## Spesa per classe terapeutica
-
-```js
-const perAtc1 = Array.from(d3.rollup(filtered, v => d3.sum(v, d => d.spesa_convenzionata), d => d.descrizione_atc1), ([descrizione_atc1, spesa]) => ({descrizione_atc1, spesa})).sort((a,b) => b.spesa - a.spesa);
-```
-
-```js
-Plot.plot({
-  title: `Spesa per classe ATC1 — ${annoSel}`,
-  width: 800,
-  height: 350,
-  marginLeft: 200,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Set2"},
-  marks: [
-    Plot.barX(perAtc1, {
-      y: "descrizione_atc1",
-      x: "spesa",
-      fill: "spesa",
-      sort: {y: "-x"},
-      tip: true
-    }),
-    Plot.ruleX([0])
-  ]
-})
-```
-
----
-
 ## Dettaglio regioni
 
 ```js
@@ -123,8 +142,6 @@ Inputs.table(perRegione, {
   width: "100%"
 })
 ```
-
----
 
 ---
 

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -1,6 +1,11 @@
 ---
 title: Spesa farmaceutica convenzionata
-description: Dati AIFA su spesa e consumo farmaceutico SSN per regione e classe terapeutica
+description: Dati AIFA su spesa e consumo farmaceutico convenzionato SSN per regione e classe terapeutica ATC, 2018-2024
+source: AIFA — Agenzia Italiana del Farmaco
+source_url: https://www.aifa.gov.it/open-data
+period: "2018–2024"
+last_modified: 2026-05-26
+dataset_slug: aifa_spesa_consumo
 ---
 
 # Spesa farmaceutica convenzionata
@@ -121,7 +126,18 @@ Inputs.table(perRegione, {
 
 ---
 
+---
+
+## Limiti
+
+- **Copertura**: la serie storica copre 2018-2024. Dati precedenti non sono disponibili in questo dataset.
+- **Convenzionata**: i dati si riferiscono alla sola farmaceutica convenzionata SSN (farmaci rimborsati dal Servizio Sanitario Nazionale). Non include la spesa farmaceutica privata o ospedaliera.
+- **Classificazione ATC**: la disaggregazione per classe terapeutica segue la classificazione Anatomico Terapeutica Chimica (ATC) livello 1. Classificazioni più granulari (ATC2, ATC3) sono disponibili nel dato originale ma non in questa pagina.
+
+---
+
 ## Risorse
 
-- [AIFA — Open Data](https://www.aifa.gov.it/open-data)
+- [AIFA — Open Data (fonte originale)](https://www.aifa.gov.it/open-data)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/aifa-spesa-consumo)

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -20,7 +20,7 @@ const data = await FileAttachment("../data/aifa-spesa.json").json();
 
 ```js
 const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
-const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,7 @@ display(html`<div class="grid grid-cols-2">
   ${themes.map(t => html`<div class="card">
     <h3><a href="/temi/${t.slug}">${t.name}</a></h3>
     <p style="opacity:0.7; font-size:0.9em">${t.description}</p>
-    <p style="font-size:0.85em">${t.datasets.length} dataset · ${t.questions.length} domande</p>
+    <p style="font-size:0.85em">${t.datasets.length} dataset</p>
   </div>`)}
 </div>`)
 ```

--- a/src/temi/finanza-pubblica.md
+++ b/src/temi/finanza-pubblica.md
@@ -28,7 +28,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
   </div>
   <div class="card">
     <h3>Periodo</h3>
-    <span class="big">${periodStart}–${periodEnd}</span>
+    <span class="big">${String(periodStart)}–${String(periodEnd)}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>

--- a/src/temi/finanza-pubblica.md
+++ b/src/temi/finanza-pubblica.md
@@ -5,8 +5,56 @@ description: Entrate dello Stato, capacità fiscale, tributi locali e acquisti i
 
 # Finanza pubblica
 
-Questo tema raccoglie dataset su finanza pubblica, tributi e spesa della PA in convenzione.
+IRPEF comunale, entrate dello Stato e consumi della PA in convenzione Consip. I dataset di questo tema coprono la finanza pubblica italiana dal livello locale a quello centrale.
 
-- [IRPEF comunale](/dataset/irpef-comunale)
-- [Entrate dello Stato](/dataset/entrate-stato)
-- [Consumi Consip](/dataset/consip-consumi-convenzione)
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "finanza-pubblica");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const periodStart = Math.min(...datasets.map(d => parseInt(d.years.split('–')[0])));
+const periodEnd = Math.max(...datasets.map(d => parseInt(d.years.split('–')[1])));
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Periodo</h3>
+    <span class="big">${periodStart}–${periodEnd}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="grid grid-cols-2">
+  ${datasets.map(d => html`<div class="card">
+    <h3><a href="/dataset/${d.url_slug}">${d.name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${d.description}</p>
+    <p style="font-size:0.85em">${d.years} · ${d.stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+  </div>`)}
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Territorio e ambiente](/temi/territorio-ambiente)
+- [Sanità](/temi/sanita)
+- [Welfare e lavoro](/temi/welfare-lavoro)
+- [Giustizia](/temi/giustizia)

--- a/src/temi/giustizia.md
+++ b/src/temi/giustizia.md
@@ -28,7 +28,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
   </div>
   <div class="card">
     <h3>Periodo</h3>
-    <span class="big">${periodStart}–${periodEnd}</span>
+    <span class="big">${String(periodStart)}–${String(periodEnd)}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>

--- a/src/temi/giustizia.md
+++ b/src/temi/giustizia.md
@@ -5,6 +5,54 @@ description: Flussi civili, tempi e carichi dei tribunali
 
 # Giustizia
 
-Questo tema raccoglie dataset su giustizia e flussi civili.
+Flussi della giustizia civile: sopravvenuti, definiti e pendenti per distretto. Il dataset di questo tema copre l'andamento del contenzioso civile nei tribunali italiani.
 
-- [Flussi giustizia civile](/dataset/flussi-giustizia-civile)
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "giustizia");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const periodStart = Math.min(...datasets.map(d => parseInt(d.years.split('–')[0])));
+const periodEnd = Math.max(...datasets.map(d => parseInt(d.years.split('–')[1])));
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Periodo</h3>
+    <span class="big">${periodStart}–${periodEnd}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="card">
+    <h3><a href="/dataset/${datasets[0].url_slug}">${datasets[0].name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${datasets[0].description}</p>
+    <p style="font-size:0.85em">${datasets[0].years} · ${datasets[0].stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Territorio e ambiente](/temi/territorio-ambiente)
+- [Finanza pubblica](/temi/finanza-pubblica)
+- [Sanità](/temi/sanita)
+- [Welfare e lavoro](/temi/welfare-lavoro)

--- a/src/temi/sanita.md
+++ b/src/temi/sanita.md
@@ -28,7 +28,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
   </div>
   <div class="card">
     <h3>Periodo</h3>
-    <span class="big">${periodStart}–${periodEnd}</span>
+    <span class="big">${String(periodStart)}–${String(periodEnd)}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>

--- a/src/temi/sanita.md
+++ b/src/temi/sanita.md
@@ -1,11 +1,60 @@
 ---
 title: Sanità
-description: Spesa farmaceutica, consumi sanitari e prevenzione
+description: Spesa farmaceutica, consumi sanitari e costi dei Livelli Essenziali di Assistenza
 ---
 
 # Sanità
 
-Questo tema raccoglie dataset su sanità, spesa farmaceutica e costi dei Livelli Essenziali di Assistenza.
+Spesa farmaceutica convenzionata e costi dei Livelli Essenziali di Assistenza (LEA) per regione. I dataset di questo tema coprono la spesa sanitaria pubblica italiana, dal farmaco al costo complessivo dei servizi sanitari regionali.
 
-- [Spesa farmaceutica](/dataset/spesa-farmaceutica)
-- [Spesa sanitaria LEA](/dataset/bdap-lea)
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "sanita");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const periodStart = Math.min(...datasets.map(d => parseInt(d.years.split('–')[0])));
+const periodEnd = Math.max(...datasets.map(d => parseInt(d.years.split('–')[1])));
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Periodo</h3>
+    <span class="big">${periodStart}–${periodEnd}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="grid grid-cols-2">
+  ${datasets.map(d => html`<div class="card">
+    <h3><a href="/dataset/${d.slug}">${d.name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${d.description}</p>
+    <p style="font-size:0.85em">${d.years} · ${d.stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+  </div>`)}
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Territorio e ambiente](/temi/territorio-ambiente)
+- [Finanza pubblica](/temi/finanza-pubblica)
+- [Welfare e lavoro](/temi/welfare-lavoro)
+- [Giustizia](/temi/giustizia)

--- a/src/temi/sanita.md
+++ b/src/temi/sanita.md
@@ -43,7 +43,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
 ```js
 display(html`<div class="grid grid-cols-2">
   ${datasets.map(d => html`<div class="card">
-    <h3><a href="/dataset/${d.slug}">${d.name}</a></h3>
+    <h3><a href="/dataset/${d.url_slug}">${d.name}</a></h3>
     <p style="opacity:0.7; font-size:0.9em">${d.description}</p>
     <p style="font-size:0.85em">${d.years} · ${d.stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
   </div>`)}

--- a/src/temi/territorio-ambiente.md
+++ b/src/temi/territorio-ambiente.md
@@ -28,7 +28,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
   </div>
   <div class="card">
     <h3>Periodo</h3>
-    <span class="big">${periodStart}–${periodEnd}</span>
+    <span class="big">${String(periodStart)}–${String(periodEnd)}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>

--- a/src/temi/territorio-ambiente.md
+++ b/src/temi/territorio-ambiente.md
@@ -5,7 +5,56 @@ description: Trasformazioni territoriali, ambiente, energia e rifiuti
 
 # Territorio e ambiente
 
-Questo tema raccoglie dataset su ambiente, rifiuti ed energia.
+Produzione e raccolta differenziata dei rifiuti urbani, capacità di generazione rinnovabile installata per regione. I dataset di questo tema coprono le trasformazioni ambientali e il mix energetico italiano.
 
-- [Rifiuti urbani](/dataset/rifiuti-urbani)
-- [Capacità rinnovabile](/dataset/capacita-rinnovabile)
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "territorio-ambiente");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const periodStart = Math.min(...datasets.map(d => parseInt(d.years.split('–')[0])));
+const periodEnd = Math.max(...datasets.map(d => parseInt(d.years.split('–')[1])));
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Periodo</h3>
+    <span class="big">${periodStart}–${periodEnd}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="grid grid-cols-2">
+  ${datasets.map(d => html`<div class="card">
+    <h3><a href="/dataset/${d.url_slug}">${d.name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${d.description}</p>
+    <p style="font-size:0.85em">${d.years} · ${d.stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+  </div>`)}
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Finanza pubblica](/temi/finanza-pubblica)
+- [Sanità](/temi/sanita)
+- [Welfare e lavoro](/temi/welfare-lavoro)
+- [Giustizia](/temi/giustizia)

--- a/src/temi/welfare-lavoro.md
+++ b/src/temi/welfare-lavoro.md
@@ -28,7 +28,7 @@ const sources = [...new Set(datasets.map(d => d.source))];
   </div>
   <div class="card">
     <h3>Periodo</h3>
-    <span class="big">${periodStart}–${periodEnd}</span>
+    <span class="big">${String(periodStart)}–${String(periodEnd)}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>

--- a/src/temi/welfare-lavoro.md
+++ b/src/temi/welfare-lavoro.md
@@ -5,7 +5,56 @@ description: Pubblico impiego, pensioni e previdenza
 
 # Welfare e lavoro
 
-Questo tema raccoglie dataset su lavoro, pensioni e pubblico impiego.
+Dipendenti pubblici per comparto e pensioni INPS per gestione previdenziale. I dataset di questo tema coprono il lavoro pubblico e la previdenza in Italia.
 
-- [Dipendenti pubblici](/dataset/dipendenti-pubblici)
-- [Pensioni INPS](/dataset/pensioni-inps)
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "welfare-lavoro");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const periodStart = Math.min(...datasets.map(d => parseInt(d.years.split('–')[0])));
+const periodEnd = Math.max(...datasets.map(d => parseInt(d.years.split('–')[1])));
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Periodo</h3>
+    <span class="big">${periodStart}–${periodEnd}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="grid grid-cols-2">
+  ${datasets.map(d => html`<div class="card">
+    <h3><a href="/dataset/${d.url_slug}">${d.name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${d.description}</p>
+    <p style="font-size:0.85em">${d.years} · ${d.stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+  </div>`)}
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Territorio e ambiente](/temi/territorio-ambiente)
+- [Finanza pubblica](/temi/finanza-pubblica)
+- [Sanità](/temi/sanita)
+- [Giustizia](/temi/giustizia)


### PR DESCRIPTION
## Sintesi

Allineamento di tutte le 10 pagine dataset e 5 pagine tema al nuovo standard definito in `docs/TEMPLATE-dataset-page.md` e `docs/dataset-page-standard.md`.

## Cosa cambia

- [x] Documentazione
- [x] Aggiornamento config / catalogo

## Dettaglio

### 10 pagine dataset — frontmatter, limiti, primo blocco

Ogni pagina ora ha:
- **Frontmatter obbligatorio**: `source`, `source_url`, `period`, `last_modified`, `dataset_slug` (prima solo 2/10 avevano source e last_modified)
- **Sezione Limiti** strutturata in fondo (prima assente in 10/10)
- **Link al parquet pulito** su GCS (prima assente in 8/10)
- **Primo blocco**: composizione/distribuzione base, non ranking

Pagine con riordino strutturale:
- **IRPEF comunale**: primo blocco → quota del reddito nazionale per regione (era ranking)
- **BDAP LEA**: primo blocco → composizione nazionale per macro-area (era ranking regioni)
- **Spesa farmaceutica**: primo blocco → composizione per classe ATC1 (era ranking regioni)

### 5 pagine tema — da placeholder a pagine dinamiche

Ogni tema ora ha:
- Cards riassuntive (dataset, periodo, fonti) lette dal catalogo live
- Card per ogni dataset con descrizione, periodo, stato
- Navigazione incrociata tra temi

### Catalogo

- Aggiunto `url_slug` in `catalog.json.py` per mappare slug DI (underscore) a URL slug (trattini) nei casi non meccanici
- Rimosso campo `questions` da `themes.json.py` e homepage (erano hardcoded)

### Bug fix

- `Inputs.select` per anno: usa `Map` per evitare formattazione numeri Observable ("2,024" → "2024")
- Period display: `String()` per evitare formattazione numeri nelle card tema

## Verifica

```bash
npm run build
```

## Checklist PR

- [x] Perimetro stretto: standardizzazione pagine esistenti, nessuna nuova feature