### PR TITLE
feat(istat-gini-regionale): aggiungi dataset explorer — indice di Gini per regione

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -19,6 +19,7 @@ export default {
         { name: "Produzione elettrica", path: "/dataset/produzione-elettrica-fonti" },
         { name: "Spesa farmaceutica", path: "/dataset/spesa-farmaceutica" },
         { name: "Entrate dello Stato", path: "/dataset/entrate-stato" },
+        { name: "Indice di Gini regionale", path: "/dataset/istat-gini-regionale" },
         { name: "Pensioni INPS", path: "/dataset/pensioni-inps" },
       ],
     },

--- a/src/data/istat-gini-regionale.json.py
+++ b/src/data/istat-gini-regionale.json.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Data loader: ISTAT Gini regionale — indice per regione e anno."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="istat_gini_regionale",
+    years=[2023],  # unico file multi-anno
+    group_cols=["anno", "regione", "pres_aff_imp"],
+    metric_cols=["gini"],
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -12,8 +12,8 @@ themes = [
     {
         "slug": "finanza-pubblica",
         "name": "Finanza pubblica",
-        "description": "Entrate dello Stato, capacità fiscale e tributi locali",
-        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione"],
+        "description": "Entrate dello Stato, capacità fiscale, tributi locali e disuguaglianza del reddito",
+        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione", "istat-gini-regionale"],
     },
     {
         "slug": "sanita",

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -1,9 +1,9 @@
 ---
 title: Indice di Gini regionale
-description: Disuguaglianza del reddito netto per regione — indice di Gini ISTAT, 2003-2023
+description: Disuguaglianza del reddito netto per regione — indice di Gini ISTAT, 2003-2024
 source: ISTAT — Dataflow 32_221
 source_url: https://esploradati.istat.it/
-period: "2003–2023"
+period: "2003–2024"
 last_modified: 2026-05-27
 dataset_slug: istat_gini_regionale
 ---
@@ -12,7 +12,7 @@ dataset_slug: istat_gini_regionale
 
 Disuguaglianza del reddito netto per regione, misurata con l'indice di Gini. I dati permettono di confrontare il livello di disuguaglianza tra territori e la sua evoluzione nel tempo.
 
-**Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2003–2023
+**Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2003–2024
 
 ```js
 const data = await FileAttachment("../data/istat-gini-regionale.json").json();
@@ -47,7 +47,7 @@ const trendNazionale = Array.from(
 
 <div class="grid grid-cols-3">
   <div class="card">
-    <h3>Gini Italia</h3>
+    <h3>Media regionale</h3>
     <span class="big">${mediaNazionale.toFixed(3)}</span>
     <small style="opacity:0.6">${annoSel} ${conFitti ? "con" : "senza"} fitti imputati</small>
   </div>
@@ -65,7 +65,7 @@ const trendNazionale = Array.from(
 
 ## Disuguaglianza per regione
 
-Quali regioni hanno la distribuzione del reddito più diseguale? L'indice di Gini varia da 0 (uguaglianza perfetta) a 1 (massima disuguaglianza). La media nazionale è rappresentata dalla linea tratteggiata.
+Quali regioni hanno la distribuzione del reddito più diseguale? L'indice di Gini varia da 0 (uguaglianza perfetta) a 1 (massima disuguaglianza). La media regionale è rappresentata dalla linea tratteggiata.
 
 ```js
 Plot.plot({
@@ -95,13 +95,13 @@ Plot.plot({
 
 ---
 
-## Evoluzione nazionale
+## Evoluzione regionale
 
-L'indice di Gini nazionale mostra una leggera riduzione della disuguaglianza tra 2003 e metà anni 2000, seguita da una risalita graduale.
+La media regionale dell'indice di Gini mostra una leggera riduzione della disuguaglianza tra 2003 e metà anni 2000, seguita da una risalita graduale.
 
 ```js
 Plot.plot({
-  title: `Andamento Gini nazionale ${conFitti ? "con" : "senza"} fitti imputati`,
+  title: `Andamento media regionale ${conFitti ? "con" : "senza"} fitti imputati`,
   width: 800,
   height: 350,
   x: {tickFormat: d => String(d), label: null},
@@ -146,10 +146,10 @@ Inputs.table(annoData, {
 
 ## Limiti
 
-- **Copertura**: la serie copre il periodo 2003-2023. Dati 2024 non ancora disponibili al momento dell'ultimo aggiornamento.
+- **Copertura**: la serie copre il periodo 2003-2024. Dati 2025 non ancora disponibili al momento dell'ultimo aggiornamento.
 - **Fitti imputati**: il toggle "Includi fitti imputati" controlla se nel reddito è incluso il valore figurativo della proprietà dell'abitazione. Con i fitti imputati la disuguaglianza è sistematicamente più bassa (~0.03 punti) perché la proprietà della casa riduce la dispersione del reddito disponibile.
 - **Indice di Gini**: misura la disuguaglianza della distribuzione del reddito netto. Non cattura disuguaglianza di ricchezza, consumi o opportunità.
-- **Media nazionale**: calcolata come media semplice delle regioni, non ponderata per popolazione.
+- **Media regionale**: calcolata come media semplice delle regioni, non ponderata per popolazione.
 
 ---
 

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -1,0 +1,160 @@
+---
+title: Indice di Gini regionale
+description: Disuguaglianza del reddito netto per regione — indice di Gini ISTAT, 2003-2023
+source: ISTAT — Dataflow 32_221
+source_url: https://esploradati.istat.it/
+period: "2003–2023"
+last_modified: 2026-05-27
+dataset_slug: istat_gini_regionale
+---
+
+# Indice di Gini regionale
+
+Disuguaglianza del reddito netto per regione, misurata con l'indice di Gini. I dati permettono di confrontare il livello di disuguaglianza tra territori e la sua evoluzione nel tempo.
+
+**Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2003–2023
+
+```js
+const data = await FileAttachment("../data/istat-gini-regionale.json").json();
+```
+
+```js
+// Filtro: default con fitti imputati (più completo per benessere economico)
+const conFitti = view(Inputs.toggle({label: "Includi fitti imputati", value: true}));
+const presAffImp = conFitti ? 1 : 2;
+const filtered = data.filter(d => d.pres_aff_imp === presAffImp);
+```
+
+```js
+const anni = [...new Set(filtered.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const annoData = filtered
+  .filter(d => d.anno === annoSel)
+  .sort((a, b) => b.gini - a.gini);
+
+const mediaNazionale = d3.mean(annoData, d => d.gini);
+```
+
+```js
+const trendNazionale = Array.from(
+  d3.rollup(filtered, v => d3.mean(v, d => d.gini), d => d.anno),
+  ([anno, gini]) => ({anno, gini})
+).sort((a, b) => a.anno - b.anno);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Gini Italia</h3>
+    <span class="big">${mediaNazionale.toFixed(3)}</span>
+    <small style="opacity:0.6">${annoSel} ${conFitti ? "con" : "senza"} fitti imputati</small>
+  </div>
+  <div class="card">
+    <h3>Regioni</h3>
+    <span class="big">${annoData.length}</span>
+  </div>
+  <div class="card">
+    <h3>Min – Max</h3>
+    <span class="big">${d3.min(annoData, d => d.gini).toFixed(3)} – ${d3.max(annoData, d => d.gini).toFixed(3)}</span>
+  </div>
+</div>
+
+---
+
+## Disuguaglianza per regione
+
+Quali regioni hanno la distribuzione del reddito più diseguale? L'indice di Gini varia da 0 (uguaglianza perfetta) a 1 (massima disuguaglianza). La media nazionale è rappresentata dalla linea tratteggiata.
+
+```js
+Plot.plot({
+  title: `Indice di Gini per regione — ${String(annoSel)}`,
+  width: 800,
+  height: 450,
+  marginLeft: 120,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, label: "Gini (0-1)", tickFormat: d => d.toFixed(2)},
+  color: {scheme: "RdYlGn"},
+  marks: [
+    Plot.barX(annoData, {
+      y: "regione",
+      x: "gini",
+      fill: "gini",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([mediaNazionale], {
+      stroke: "var(--theme-foreground-muted)",
+      strokeDasharray: "4,4"
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Evoluzione nazionale
+
+L'indice di Gini nazionale mostra una leggera riduzione della disuguaglianza tra 2003 e metà anni 2000, seguita da una risalita graduale.
+
+```js
+Plot.plot({
+  title: `Andamento Gini nazionale ${conFitti ? "con" : "senza"} fitti imputati`,
+  width: 800,
+  height: 350,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, label: "Gini (0-1)"},
+  marks: [
+    Plot.lineY(trendNazionale, {
+      x: "anno",
+      y: "gini",
+      tip: {format: {y: d => d.toFixed(3)}}
+    }),
+    Plot.dot(trendNazionale, {
+      x: "anno",
+      y: "gini",
+      fill: "steelblue",
+      r: 2
+    }),
+    Plot.areaY(trendNazionale, {
+      x: "anno",
+      y: "gini",
+      fill: "steelblue",
+      fillOpacity: 0.05
+    })
+  ]
+})
+```
+
+---
+
+## Dettaglio per regione
+
+```js
+Inputs.table(annoData, {
+  columns: ["regione", "gini"],
+  header: {regione: "Regione", gini: "Indice di Gini"},
+  format: {gini: x => x.toFixed(3)},
+  rows: 25,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2003-2023. Dati 2024 non ancora disponibili al momento dell'ultimo aggiornamento.
+- **Fitti imputati**: il toggle "Includi fitti imputati" controlla se nel reddito è incluso il valore figurativo della proprietà dell'abitazione. Con i fitti imputati la disuguaglianza è sistematicamente più bassa (~0.03 punti) perché la proprietà della casa riduce la dispersione del reddito disponibile.
+- **Indice di Gini**: misura la disuguaglianza della distribuzione del reddito netto. Non cattura disuguaglianza di ricchezza, consumi o opportunità.
+- **Media nazionale**: calcolata come media semplice delle regioni, non ponderata per popolazione.
+
+---
+
+## Risorse
+
+- [ISTAT — Esplora dati](https://esploradati.istat.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_gini_regionale/2023/istat_gini_regionale_2023_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-gini-regionale)

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -133,10 +133,18 @@ Plot.plot({
 ## Dettaglio per regione
 
 ```js
-Inputs.table(annoData, {
-  columns: ["regione", "gini"],
-  header: {regione: "Regione", gini: "Indice di Gini"},
-  format: {gini: x => x.toFixed(3)},
+const annoConDelta = annoData.map((d, i) => ({
+  ...d,
+  pos: i + 1,
+  diff_media: d.gini - mediaNazionale
+}));
+```
+
+```js
+Inputs.table(annoConDelta, {
+  columns: ["pos", "regione", "gini", "diff_media"],
+  header: {pos: "#", regione: "Regione", gini: "Gini", diff_media: "Δ media"},
+  format: {gini: x => x.toFixed(3), diff_media: x => (x > 0 ? "+" : "") + x.toFixed(3)},
   rows: 25,
   width: "100%"
 })

--- a/src/temi/finanza-pubblica.md
+++ b/src/temi/finanza-pubblica.md
@@ -5,7 +5,7 @@ description: Entrate dello Stato, capacità fiscale, tributi locali e acquisti i
 
 # Finanza pubblica
 
-IRPEF comunale, entrate dello Stato e consumi della PA in convenzione Consip. I dataset di questo tema coprono la finanza pubblica italiana dal livello locale a quello centrale.
+IRPEF comunale, entrate dello Stato, consumi della PA in convenzione Consip e disuguaglianza del reddito per regione. I dataset di questo tema coprono la finanza pubblica italiana dal livello locale a quello centrale.
 
 ```js
 const catalog = await FileAttachment("../data/catalog.json").json();


### PR DESCRIPTION
## Cosa

Pagina dataset per **ISTAT Gini regionale** — indice di Gini sul reddito netto per regione, 2003-2023.

### File creati

| File | Ruolo |
|---|---|
| `src/data/istat-gini-regionale.json.py` | Loader: Gini per anno, regione e serie |
| `src/dataset/istat-gini-regionale.md` | Pagina standard |

### Struttura pagina

1. KPI card: media nazionale, regioni, range min-max
2. **Toggle** "Includi fitti imputati" — default ON (misura più completa)
3. **Primo blocco**: Gini per regione (anno selezionabile) con linea media nazionale
4. **Secondo blocco**: trend nazionale 2003-2023
5. Tabella dettaglio
6. Limiti con nota metodologica sui fitti imputati

### Note

- Dataset ancora incubating in DI — dopo il merge lo promuoviamo a published
- Toggle con/senza fitti imputati per confronto metodologico
