### PR TITLE
feat: heatmap pendenti distretto×anno in giustizia

### DIFF
--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -64,6 +64,7 @@ La heatmap mostra in un colpo solo l'evoluzione dei pendenti in tutti i distrett
 // Dati per heatmap: exclude rows with missing distretto, aggregate if needed
 const heatmapData = data
   .filter(d => d.distretto)
+  .map(d => ({...d, anno_str: String(d.anno)}))
   .sort((a, b) => a.anno - b.anno);
 const distretti = [...new Set(heatmapData.map(d => d.distretto))].sort();
 ```
@@ -75,18 +76,18 @@ Plot.plot({
   height: Math.max(400, distretti.length * 22 + 40),
   marginLeft: 140,
   marginTop: 30,
-  x: {label: null, tickFormat: d => String(d)},
+  x: {label: null},
   y: {label: null, tickSize: 0},
   color: {scheme: "Reds", legend: true, type: "symlog"},
   marks: [
     Plot.cell(heatmapData, {
-      x: "anno",
+      x: "anno_str",
       y: "distretto",
       fill: "pendenti_finali",
       tip: {format: {fill: d => d.toLocaleString("it-IT")}}
     }),
     Plot.text(heatmapData, {
-      x: "anno",
+      x: "anno_str",
       y: "distretto",
       text: d => (d.pendenti_finali / 1000).toFixed(0) + "k",
       fill: d => d.pendenti_finali > 80000 ? "white" : "var(--theme-foreground-muted)",

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -56,31 +56,47 @@ const totPendenti = filtered.reduce((s, d) => s + d.pendenti_finali, 0);
 
 ---
 
-## Pendenti per distretto
+## Pendenti per distretto e anno
+
+La heatmap mostra in un colpo solo l'evoluzione dei pendenti in tutti i distretti dal 2014 al 2025. Ogni cella è un distretto in un anno: più scura è la cella, più alto è il carico pendente. Si vede immediatamente quali distretti hanno più arretrato e come cambia nel tempo.
+
+```js
+// Dati per heatmap: exclude rows with missing distretto, aggregate if needed
+const heatmapData = data
+  .filter(d => d.distretto)
+  .sort((a, b) => a.anno - b.anno);
+const distretti = [...new Set(heatmapData.map(d => d.distretto))].sort();
+```
 
 ```js
 Plot.plot({
-  title: `Pendenti finali per distretto — ${annoSel}`,
+  title: "Pendenti per distretto e anno — giustizia civile",
   width: 800,
-  height: 450,
+  height: Math.max(400, distretti.length * 22 + 40),
   marginLeft: 140,
+  marginTop: 30,
+  x: {label: null, tickFormat: d => String(d)},
   y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Reds"},
+  color: {scheme: "Reds", legend: true, type: "symlog"},
   marks: [
-    Plot.barX(filtered, {
+    Plot.cell(heatmapData, {
+      x: "anno",
       y: "distretto",
-      x: "pendenti_finali",
       fill: "pendenti_finali",
-      sort: {y: "-x"},
-      tip: true
+      tip: {format: {fill: d => d.toLocaleString("it-IT")}}
     }),
-    Plot.ruleX([0])
+    Plot.text(heatmapData, {
+      x: "anno",
+      y: "distretto",
+      text: d => (d.pendenti_finali / 1000).toFixed(0) + "k",
+      fill: d => d.pendenti_finali > 80000 ? "white" : "var(--theme-foreground-muted)",
+      fontSize: 9
+    })
   ]
 })
 ```
 
----
+Un rapporto > 1 significa che il distretto ha definito più cause di quante ne siano sopravvenute (smaltimento). &lt; 1 indica accumulo. I dettagli per anno selezionato sono nei blocchi seguenti.
 
 ## Rapporto definiti / sopravvenuti
 
@@ -90,7 +106,7 @@ const rapportoFiltered = [...filtered].sort((a, b) => a.rapporto_def_sop - b.rap
 
 ```js
 Plot.plot({
-  title: `Rapporto definiti / sopravvenuti per distretto — ${annoSel}`,
+  title: `Rapporto definiti / sopravvenuti per distretto — ${String(annoSel)}`,
   width: 800,
   height: 450,
   marginLeft: 140,
@@ -126,8 +142,6 @@ Inputs.table(filtered, {
   width: "100%"
 })
 ```
-
----
 
 ---
 

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -76,7 +76,7 @@ Plot.plot({
   height: Math.max(400, distretti.length * 22 + 40),
   marginLeft: 140,
   marginTop: 30,
-  x: {label: null},
+  x: {label: null, type: "band"},
   y: {label: null, tickSize: 0},
   color: {scheme: "Reds", legend: true, type: "symlog"},
   marks: [


### PR DESCRIPTION
## Cosa

Sostituisce la bar chart "Pendenti per distretto" (un anno alla volta) con una **heatmap** che mostra pendenti per distretto × anno (2014-2025) in un solo colpo.

### Prima
- Bar chart con un anno selezionabile via dropdown
- Per vedere l'evoluzione bisognava cambiare anno manualmente

### Dopo
- Heatmap `Plot.cell`: distretti sull'asse Y, anni sull'asse X, colore = pendenti
- Unico grafico: si vede subito quali distretti hanno più arretrato e come evolve nel tempo
- Testo con valore in migliaia dentro ogni cella
- Dropdown anno resta per il grafico "Rapporto D/S" e la tabella

### Note
- `String(annoSel)` aggiunto nel titolo del rapporto D/S
- Doppio `---` rimosso
