### PR TITLE
feat(popolazione-istat): piramide demografica + sidebar per tema

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -40,6 +40,7 @@ export default {
         { name: "Pensioni INPS", path: "/dataset/pensioni-inps" },
         { name: "Indice prezzi IPAB", path: "/dataset/istat-ipab-aree" },
         { name: "Alunni corso/età", path: "/dataset/mim-alunni-corso-eta" },
+        { name: "Popolazione per età", path: "/dataset/popolazione-istat" },
       ],
     },
     {
@@ -54,18 +55,6 @@ export default {
       collapsible: true,
       pages: [
         { name: "Votazioni Camera", path: "/dataset/votazioni-camera" },
-        { name: "Popolazione per età", path: "/dataset/popolazione-istat" },
-      ],
-    },
-    {
-      name: "Temi",
-      collapsible: false,
-      pages: [
-        { name: "Territorio e ambiente", path: "/temi/territorio-ambiente" },
-        { name: "Finanza pubblica", path: "/temi/finanza-pubblica" },
-        { name: "Sanità", path: "/temi/sanita" },
-        { name: "Welfare e lavoro", path: "/temi/welfare-lavoro" },
-        { name: "Giustizia", path: "/temi/giustizia" },
       ],
     },
   ],

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -5,25 +5,56 @@ export default {
   theme: ["air", "ocean-floor"],
   pages: [
     {
-      name: "Dataset",
-      collapsible: false,
+      name: "Territorio e ambiente",
+      collapsible: true,
       pages: [
-        { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
-        { name: "Indice prezzi IPAB", path: "/dataset/istat-ipab-aree" },
-        { name: "Consumi Consip", path: "/dataset/consip-consumi-convenzione" },
-        { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
         { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
-        { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },
-        { name: "Dipendenti pubblici", path: "/dataset/dipendenti-pubblici" },
         { name: "Capacità rinnovabile", path: "/dataset/capacita-rinnovabile" },
         { name: "Produzione elettrica", path: "/dataset/produzione-elettrica-fonti" },
-        { name: "Spesa farmaceutica", path: "/dataset/spesa-farmaceutica" },
+      ],
+    },
+    {
+      name: "Finanza pubblica",
+      collapsible: true,
+      pages: [
+        { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
         { name: "Entrate dello Stato", path: "/dataset/entrate-stato" },
+        { name: "Consumi Consip", path: "/dataset/consip-consumi-convenzione" },
         { name: "Fondo Solidarietà Comunale", path: "/dataset/opencivitas-fsc-2025" },
         { name: "Indice di Gini regionale", path: "/dataset/istat-gini-regionale" },
+      ],
+    },
+    {
+      name: "Sanità",
+      collapsible: true,
+      pages: [
+        { name: "Spesa farmaceutica", path: "/dataset/spesa-farmaceutica" },
+        { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
+      ],
+    },
+    {
+      name: "Welfare e lavoro",
+      collapsible: true,
+      pages: [
+        { name: "Dipendenti pubblici", path: "/dataset/dipendenti-pubblici" },
         { name: "Pensioni INPS", path: "/dataset/pensioni-inps" },
+        { name: "Indice prezzi IPAB", path: "/dataset/istat-ipab-aree" },
         { name: "Alunni corso/età", path: "/dataset/mim-alunni-corso-eta" },
+      ],
+    },
+    {
+      name: "Giustizia",
+      collapsible: true,
+      pages: [
+        { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },
+      ],
+    },
+    {
+      name: "Altri dataset",
+      collapsible: true,
+      pages: [
         { name: "Votazioni Camera", path: "/dataset/votazioni-camera" },
+        { name: "Popolazione per età", path: "/dataset/popolazione-istat" },
       ],
     },
     {

--- a/src/data/popolazione-istat.json.py
+++ b/src/data/popolazione-istat.json.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Data loader: Popolazione ISTAT — per anno e fascia d'età."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="popolazione_istat_comunale_2019_2025",
+    years=list(range(2019, 2026)),
+    group_cols=["anno", "fascia_eta"],
+    metric_cols=["popolazione_residente", "totale_maschi", "totale_femmine"],
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -25,7 +25,7 @@ themes = [
         "slug": "welfare-lavoro",
         "name": "Welfare e lavoro",
         "description": "Pubblico impiego, pensioni, istruzione e prezzi delle abitazioni",
-        "datasets": ["dipendenti-pubblici", "pensioni-inps", "istat-ipab-aree", "mim-alunni-corso-eta"],
+        "datasets": ["dipendenti-pubblici", "pensioni-inps", "istat-ipab-aree", "mim-alunni-corso-eta", "popolazione-istat"],
     },
     {
         "slug": "giustizia",

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -51,8 +51,9 @@ const trend = Array.from(
     <span class="big">${nFasce}</span>
   </div>
   <div class="card">
-    <h3>Anni</h3>
+    <h3>Serie storica</h3>
     <span class="big">${anni.length}</span>
+    <small style="opacity:0.6">${Math.min(...anni)}–${Math.max(...anni)}</small>
   </div>
 </div>
 

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -30,6 +30,7 @@ const filtered = data.filter(d => d.anno === annoSel).sort((a, b) => {
 });
 
 const totale = d3.sum(filtered, d => d.popolazione_residente);
+const pctFemmine = d3.sum(filtered, d => d.totale_femmine) / totale * 100;
 const nFasce = filtered.length;
 ```
 
@@ -47,13 +48,13 @@ const trend = Array.from(
     <span class="big">${(totale / 1e6).toFixed(1)} <small style="opacity:0.6">mln</small></span>
   </div>
   <div class="card">
-    <h3>Fasce d'età</h3>
-    <span class="big">${nFasce}</span>
+    <h3>Femmine</h3>
+    <span class="big">${pctFemmine.toFixed(1)}%</span>
+    <small style="opacity:0.6">maschi ${(100 - pctFemmine).toFixed(1)}%</small>
   </div>
   <div class="card">
-    <h3>Serie storica</h3>
-    <span class="big">${anni.length}</span>
-    <small style="opacity:0.6">${Math.min(...anni)}–${Math.max(...anni)}</small>
+    <h3>Fasce d'età</h3>
+    <span class="big">${nFasce}</span>
   </div>
 </div>
 

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -1,0 +1,187 @@
+---
+title: Popolazione italiana per età
+description: Popolazione residente italiana per fascia d'età e anno — ISTAT, 2019-2025
+source: ISTAT — POSAS (Popolazione residente per sesso, età e comune)
+source_url: https://esploradati.istat.it/
+period: "2019–2025"
+last_modified: 2026-06-01
+dataset_slug: popolazione_istat_comunale_2019_2025
+---
+
+# Popolazione italiana per età
+
+Popolazione residente italiana per fascia d'età, sesso e anno. I dati mostrano la struttura demografica del paese e la sua evoluzione nel tempo.
+
+**Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2019–2025
+
+```js
+const data = await FileAttachment("../data/popolazione-istat.json").json();
+```
+
+```js
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const filtered = data.filter(d => d.anno === annoSel).sort((a, b) => {
+  const order = {"0-14": 1, "15-29": 2, "30-44": 3, "45-59": 4, "60-74": 5, "75+": 6};
+  return (order[a.fascia_eta] || 0) - (order[b.fascia_eta] || 0);
+});
+
+const totale = d3.sum(filtered, d => d.popolazione_residente);
+const nFasce = filtered.length;
+```
+
+```js
+// Trend per fascia
+const trend = Array.from(
+  d3.rollup(data, v => d3.sum(v, d => d.popolazione_residente), d => d.anno, d => d.fascia_eta),
+  ([anno, fasce]) => ({anno, ...Object.fromEntries(fasce)})
+).sort((a, b) => a.anno - b.anno);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Popolazione</h3>
+    <span class="big">${(totale / 1e6).toFixed(1)} <small style="opacity:0.6">mln</small></span>
+  </div>
+  <div class="card">
+    <h3>Fasce d'età</h3>
+    <span class="big">${nFasce}</span>
+  </div>
+  <div class="card">
+    <h3>Anni</h3>
+    <span class="big">${anni.length}</span>
+  </div>
+</div>
+
+---
+
+## Popolazione per fascia d'età
+
+Come si distribuisce la popolazione italiana tra le fasce d'età? Il grafico mostra la composizione per classe di età, divisa tra maschi e femmine.
+
+```js
+// Gender split per fascia
+const fasciaGenere = data
+  .filter(d => d.anno === annoSel)
+  .sort((a, b) => {
+    const order = {"0-14": 1, "15-29": 2, "30-44": 3, "45-59": 4, "60-74": 5, "75+": 6};
+    return (order[a.fascia_eta] || 0) - (order[b.fascia_eta] || 0);
+  });
+```
+
+```js
+Plot.plot({
+  title: `Popolazione per fascia d'età — ${String(annoSel)}`,
+  width: 800,
+  height: 350,
+  marginLeft: 80,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {legend: true},
+  marks: [
+    Plot.barX(fasciaGenere, {
+      y: "fascia_eta",
+      x: "totale_maschi",
+      fill: "#4e79a7",
+      tip: {title: "Maschi"}
+    }),
+    Plot.barX(fasciaGenere, {
+      y: "fascia_eta",
+      x: d => -d.totale_femmine,
+      fill: "#e15759",
+      tip: {title: "Femmine"}
+    }),
+    Plot.text(fasciaGenere, {
+      y: "fascia_eta",
+      x: "totale_maschi",
+      text: d => Math.round(d.totale_maschi / 1000000 * 10) / 10 + "M",
+      dx: 4,
+      textAnchor: "start",
+      fill: "var(--theme-foreground-muted)",
+      fontSize: 10
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+Il grafico a specchio mostra la distribuzione maschi (destra, blu) e femmine (sinistra, rossa) per fascia d'età. Le fasce più giovani tendono ad avere più maschi, quelle più anziane più femmine (maggiore speranza di vita femminile).
+
+---
+
+## Evoluzione per fascia d'età
+
+Come cambia la popolazione nelle diverse fasce d'età? I giovani (0-14 e 15-29) sono in calo, gli over 60 in crescita.
+
+```js
+const trendOrder = ["0-14", "15-29", "30-44", "45-59", "60-74", "75+"];
+const trendLong = trend.flatMap(d => 
+  trendOrder.map(f => ({anno: d.anno, fascia: f, pop: d[f] || 0}))
+);
+```
+
+```js
+Plot.plot({
+  title: "Andamento per fascia d'età — 2019-2025",
+  width: 800,
+  height: 400,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, tickFormat: "~s", label: "Popolazione"},
+  color: {legend: true},
+  marks: [
+    Plot.line(trendLong, {
+      x: "anno",
+      y: "pop",
+      z: "fascia",
+      stroke: "fascia",
+      tip: true
+    }),
+    Plot.dot(trendLong, {
+      x: "anno",
+      y: "pop",
+      z: "fascia",
+      fill: "fascia",
+      r: 2
+    })
+  ]
+})
+```
+
+---
+
+## Dettaglio per fascia
+
+```js
+Inputs.table(filtered, {
+  columns: ["fascia_eta", "popolazione_residente", "totale_maschi", "totale_femmine"],
+  header: {fascia_eta: "Fascia d'età", popolazione_residente: "Totale", totale_maschi: "Maschi", totale_femmine: "Femmine"},
+  format: {
+    popolazione_residente: x => x.toLocaleString("it-IT"),
+    totale_maschi: x => x.toLocaleString("it-IT"),
+    totale_femmine: x => x.toLocaleString("it-IT")
+  },
+  rows: 10,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2019-2025. Dati precedenti non sono disponibili in questo dataset.
+- **Fasce d'età**: la classificazione per fascia d'età segue la definizione ISTAT. I dati per singola età (0-100) sono disponibili nel dataset originale.
+- **Stato civile**: il dataset include anche la disaggregazione per stato civile (celibi, coniugati, ecc.) non mostrata in questa pagina.
+- **Popolazione residente**: i dati si riferiscono alla popolazione residente in Italia al 1° gennaio di ogni anno. Non include italiani all'estero (AIRE) né stranieri non residenti.
+- **Dettaglio territoriale**: i dati sono aggregati a livello nazionale. La disaggregazione comunale e regionale è disponibile nel dataset originale.
+
+---
+
+## Risorse
+
+- [ISTAT — Esplora dati](https://esploradati.istat.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2025/popolazione_istat_comunale_2019_2025_2025_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/popolazione-istat-comunale-2019-2025)

--- a/src/temi/welfare-lavoro.md
+++ b/src/temi/welfare-lavoro.md
@@ -5,7 +5,7 @@ description: Pubblico impiego, pensioni, previdenza e prezzi delle abitazioni
 
 # Welfare e lavoro
 
-Dipendenti pubblici, pensioni INPS, alunni per corso/età e indice dei prezzi delle abitazioni per area geografica. I dataset di questo tema coprono il lavoro pubblico, la previdenza, l'istruzione e il mercato immobiliare in Italia.
+Dipendenti pubblici, pensioni INPS, alunni per corso/età, popolazione residente e indice dei prezzi delle abitazioni per area geografica. I dataset di questo tema coprono il lavoro pubblico, la previdenza, l'istruzione, la demografia e il mercato immobiliare in Italia.
 
 ```js
 const catalog = await FileAttachment("../data/catalog.json").json();


### PR DESCRIPTION
## Cosa

### Nuovo dataset: Popolazione per età

Pagina dataset per **Popolazione ISTAT 2019-2025** — popolazione residente per fascia d'età, sesso e anno, aggregata a livello nazionale.

- **Primo blocco**: grafico a specchio maschi/femmine per fascia d'età (piramide demografica)
- **Secondo blocco**: trend per fascia 2019-2025
- Tema: **Welfare e lavoro**

### Sidebar ristrutturata

La sidebar ora raggruppa i dataset per tema in sezioni collassabili invece di una lista piatta:

- Territorio e ambiente (3)
- Finanza pubblica (5)
- Sanità (2)
- Welfare e lavoro (5)
- Giustizia (1)
- Altri dataset (2 — orfani di tema)
- Temi (invariato)
