### PR TITLE
feat: mappe coropletiche per rifiuti urbani, IRPEF e FSC

### DIFF
--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -15,6 +15,14 @@ Contribuenti, reddito imponibile e imposta netta IRPEF per comune italiano. I da
 **Fonte**: [MEF — Dipartimento delle Finanze](https://www1.finanze.gov.it/) · **Periodo**: 2019–2023
 
 ```js
+import * as topojson from "npm:topojson-client";
+
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
+const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+```
+
+```js
 const regioni = await FileAttachment("../data/irpef-regioni.json").json();
 const capoluoghi = await FileAttachment("../data/irpef-capoluoghi.json").json();
 ```
@@ -65,34 +73,33 @@ const nRegioni = new Set(regFiltered.map(d => d.regione)).size;
 
 ## Composizione del reddito per regione
 
-Come si distribuisce il reddito imponibile tra le regioni italiane? Il grafico mostra la quota di ciascuna regione sul totale nazionale: le regioni più popolose pesano di più, ma il dato pro capite — non ancora presente in questa pagina — darebbe un quadro più preciso della capacità fiscale reale.
-
 ```js
+function normalizzaReg(nome) {
+  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
+}
+
 const totNazionale = d3.sum(regFiltered, d => d.reddito_imponibile_eur);
-const conQuota = regFiltered.map(d => ({
-  ...d,
-  quota_pct: d.reddito_imponibile_eur / totNazionale * 100
-})).sort((a, b) => b.quota_pct - a.quota_pct);
+const irpefLookup = new Map(regFiltered.map(d => [normalizzaReg(d.regione), d.reddito_imponibile_eur / totNazionale * 100]));
 ```
 
 ```js
 Plot.plot({
-  title: `Quota del reddito nazionale per regione — ${annoSel}`,
+  title: `Quota del reddito nazionale per regione — ${String(annoSel)}`,
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 450,
-  marginLeft: 120,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, label: "% del totale nazionale", tickFormat: d => d.toFixed(1) + "%"},
-  color: {scheme: "Blues"},
+  height: 600,
+  color: {scheme: "YlOrRd", legend: true, label: "% reddito nazionale", type: "quantile"},
   marks: [
-    Plot.barX(conQuota, {
-      y: "regione",
-      x: "quota_pct",
-      fill: "quota_pct",
-      sort: {y: "-x"},
-      tip: {format: {x: d => d.toFixed(1) + "%"}}
+    Plot.geo(regioniGeo, {
+      fill: d => irpefLookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#fff",
+      strokeWidth: 0.25,
+      tip: true
     }),
-    Plot.ruleX([0])
+    Plot.geo(confiniReg, {
+      stroke: "#fff",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -112,12 +112,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => irpefLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -112,12 +112,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => irpefLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -79,7 +79,27 @@ function normalizzaReg(nome) {
 }
 
 const totNazionale = d3.sum(regFiltered, d => d.reddito_imponibile_eur);
-const irpefLookup = new Map(regFiltered.map(d => [normalizzaReg(d.regione), d.reddito_imponibile_eur / totNazionale * 100]));
+// Costruisci lookup escludendo MANCANTE/ERRATA e aggregando Trentino
+const irpefLookup = new Map();
+const trentinoVal = {val: 0, cnt: 0};
+for (const d of regFiltered) {
+  const r = d.regione;
+  if (r === 'MANCANTE/ERRATA') continue;
+  if (r.includes('P.A.')) {
+    trentinoVal.val += d.reddito_imponibile_eur / totNazionale * 100;
+    trentinoVal.cnt++;
+    continue;
+  }
+  irpefLookup.set(normalizzaReg(r), d.reddito_imponibile_eur / totNazionale * 100);
+}
+// Trentino unificato
+const trentKey = normalizzaReg('Trentino-Alto Adige');
+irpefLookup.set(trentKey, trentinoVal.cnt > 0 ? trentinoVal.val : 0);
+irpefLookup.set(trentKey + '/SÜDTIROL', irpefLookup.get(trentKey));
+// Valle d'Aosta fallback
+if (irpefLookup.has("VALLE-D'AOSTA")) {
+  irpefLookup.set("VALLE-D'AOSTA/VALLÉE-D'AOSTE", irpefLookup.get("VALLE-D'AOSTA"));
+}
 ```
 
 ```js

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -97,12 +97,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => giniLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#fff",
+      stroke: "#888",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#fff",
+      stroke: "#888",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -15,6 +15,14 @@ Fondo di Solidarietà Comunale (FSC) 2025 per comune: capacità fiscale, fondo p
 **Fonte**: [OpenCivitas](https://www.opencivitas.it/) · **Periodo**: 2025
 
 ```js
+import * as topojson from "npm:topojson-client";
+
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
+const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+```
+
+```js
 const data = await FileAttachment("../data/opencivitas-fsc-2025.json").json();
 ```
 
@@ -64,26 +72,32 @@ const percContribNetti = (contribNetti / nComuni * 100).toFixed(1);
 
 ## Dotazione FSC per regione
 
-Come si distribuisce il Fondo di Solidarietà tra le regioni? Lombardia, Campania e Sicilia guidano la classifica per volume totale di risorse.
+```js
+function normalizzaReg(nome) {
+  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
+}
+
+const fscLookup = new Map(perRegione.map(d => [normalizzaReg(d.regione), d.fsc]));
+```
 
 ```js
 Plot.plot({
   title: "Dotazione FSC per regione — 2025",
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 450,
-  marginLeft: 120,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Blues"},
+  height: 600,
+  color: {scheme: "Blues", legend: true, label: "Dotazione FSC (€)", type: "quantile"},
   marks: [
-    Plot.barX(perRegione, {
-      y: "regione",
-      x: "fsc",
-      fill: "fsc",
-      sort: {y: "-x"},
+    Plot.geo(regioniGeo, {
+      fill: d => fscLookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#fff",
+      strokeWidth: 0.25,
       tip: true
     }),
-    Plot.ruleX([0])
+    Plot.geo(confiniReg, {
+      stroke: "#fff",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -90,12 +90,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => fscLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -90,12 +90,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => fscLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -88,11 +88,21 @@ Plot.plot({
   height: 600,
   color: {scheme: "Blues", legend: true, label: "Dotazione FSC (€)", type: "quantile"},
   marks: [
+    // RSO: colore per dotazione FSC
     Plot.geo(regioniGeo, {
+      filter: d => fscLookup.has(normalizzaReg(d.properties.DEN_REG)),
       fill: d => fscLookup.get(normalizzaReg(d.properties.DEN_REG)),
       stroke: "#888",
       strokeWidth: 0.25,
       tip: true
+    }),
+    // Regioni a statuto speciale: grigio
+    Plot.geo(regioniGeo, {
+      filter: d => !fscLookup.has(normalizzaReg(d.properties.DEN_REG)),
+      fill: "#e0e0e0",
+      stroke: "#888",
+      strokeWidth: 0.25,
+      tip: {format: {fill: () => "Dato non disponibile (RSO)"}}
     }),
     Plot.geo(confiniReg, {
       stroke: "#888",
@@ -101,6 +111,7 @@ Plot.plot({
   ]
 })
 ```
+> Il FSC copre solo le Regioni a Statuto Ordinario (RSO). Le regioni in grigio (Sicilia, Sardegna, Friuli-Venezia Giulia, Trentino-Alto Adige e Valle d'Aosta) non sono incluse nel dataset.
 
 ---
 

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -98,12 +98,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => rdLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#666",
+      stroke: "#888",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -81,6 +81,11 @@ function normalizzaReg(nome) {
 }
 
 const rdLookup = new Map(regFiltered.map(d => [normalizzaReg(d.regione), d.quota_rd]));
+// Fallback per nomi regione non standard (ISPRA vs TopoJSON)
+const rdFALLBACKS = {"VALLE-DAOSTA": "VALLE-D'AOSTA/VALLÉE-D'AOSTE", "TRENTINO-ALTO-ADIGE": "TRENTINO-ALTO-ADIGE/SÜDTIROL"};
+for (const [short, full] of Object.entries(rdFALLBACKS)) {
+  if (rdLookup.has(short) && !rdLookup.has(full)) rdLookup.set(full, rdLookup.get(short));
+}
 ```
 
 ```js

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -98,12 +98,12 @@ Plot.plot({
   marks: [
     Plot.geo(regioniGeo, {
       fill: d => rdLookup.get(normalizzaReg(d.properties.DEN_REG)),
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.25,
       tip: true
     }),
     Plot.geo(confiniReg, {
-      stroke: "#fff",
+      stroke: "#666",
       strokeWidth: 0.7
     })
   ]

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -15,17 +15,25 @@ Dati ISPRA sui rifiuti urbani dei comuni italiani. Produzione totale, raccolta d
 **Fonte**: ISPRA · **Periodo**: 2020–2024
 
 ```js
-const regioni = await FileAttachment("../data/ispra-regioni.json").json();
+import * as topojson from "npm:topojson-client";
+
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
+const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+```
+
+```js
+const rifiutiData = await FileAttachment("../data/ispra-regioni.json").json();
 const comuni = await FileAttachment("../data/ispra-comuni.json").json();
 ```
 
 ```js
-const anni = [...new Set(regioni.map(d => d.anno))].sort((a, b) => b - a);
+const anni = [...new Set(rifiutiData.map(d => d.anno))].sort((a, b) => b - a);
 const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js
-const regFiltered = regioni
+const regFiltered = rifiutiData
   .filter(d => d.anno === annoSel)
   .sort((a, b) => b.totale_ru_tonnellate - a.totale_ru_tonnellate)
   .map(d => ({
@@ -67,24 +75,32 @@ const comuniFiltrati = comuni
 ## Raccolta differenziata per regione
 
 ```js
+// Normalizzazione nomi regione
+function normalizzaReg(nome) {
+  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
+}
+
+const rdLookup = new Map(regFiltered.map(d => [normalizzaReg(d.regione), d.quota_rd]));
+```
+
+```js
 Plot.plot({
   title: `Quota raccolta differenziata per regione — ${String(annoSel)}`,
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 450,
-  marginLeft: 120,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, label: "% RD"},
-  color: {scheme: "RdYlGn"},
+  height: 600,
+  color: {scheme: "YlGn", legend: true, label: "% RD", type: "quantile"},
   marks: [
-    Plot.barX(regFiltered, {
-      y: "regione",
-      x: "quota_rd",
-      fill: "quota_rd",
-      sort: {y: "-x"},
+    Plot.geo(regioniGeo, {
+      fill: d => rdLookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#fff",
+      strokeWidth: 0.25,
       tip: true
     }),
-    Plot.ruleX([0]),
-    Plot.ruleX([mediaRd], {stroke: "var(--theme-foreground-muted)", strokeDasharray: "4,4"})
+    Plot.geo(confiniReg, {
+      stroke: "#fff",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```


### PR DESCRIPTION
## Cosa

Estensione del pattern mappa (Plot.geo + topojson-client) ad altri 3 dataset regionali.

### Pagine modificate

| Pagina | Prima | Dopo | Lookup |
|---|---|---|---|
| **Rifiuti urbani** | Bar chart % RD per regione | Mappa coropletica YlGn | Fallback per `Valle dAosta` e `Trentino-Alto Adige` (ISPRA vs TopoJSON) |
| **IRPEF comunale** | Bar chart quota reddito per regione | Mappa coropletica YlOrRd | Province Autonome aggregate in Trentino, `MANCANTE/ERRATA` escluso |
| **FSC 2025** | Bar chart dotazione FSC per regione | Mappa coropletica Blues | Solo RSO (15 regioni), match diretto |

### Pattern comune

```js
import * as topojson from "npm:topojson-client";
const regTopo = await FileAttachment("../data/regioni.topojson").json();
const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
```

TopoJSON già presente in `src/data/` da PR #128.

### Note

- `normalizzaReg()` gestisce spazi, slash e maiuscole
- Fallback lookup per nomi regione non standard (ISPRA, MEF vs ISTAT TopoJSON)
- I grafici secondari (Grandi comuni, Capoluoghi, Perequativo) sono invariati
