### PR TITLE
feat(mit-incidentalita): incidenti stradali — trend 2001-2018

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -11,6 +11,7 @@ export default {
         { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
         { name: "Capacità rinnovabile", path: "/dataset/capacita-rinnovabile" },
         { name: "Produzione elettrica", path: "/dataset/produzione-elettrica-fonti" },
+        { name: "Incidenti stradali", path: "/dataset/mit-incidentalita" },
       ],
     },
     {

--- a/src/data/mit-incidentalita.json.py
+++ b/src/data/mit-incidentalita.json.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Data loader: MIT incidentalità stradale — mensile nazionale."""
+import sys; sys.path.insert(0, "src/data")
+from _util import load_dataset
+
+load_dataset(
+    slug="mit_incidentalita_mensile",
+    years=[2001],  # unico file multi-anno
+    group_cols=["anno", "mese", "mese_numero"],
+    metric_cols=["incidenti", "morti", "feriti", "incidenti_mortali",
+                 "indice_mortalita", "indice_gravita", "indice_lesivita"],
+)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -6,8 +6,8 @@ themes = [
     {
         "slug": "territorio-ambiente",
         "name": "Territorio e ambiente",
-        "description": "Trasformazioni territoriali, ambiente, energia e rifiuti",
-        "datasets": ["rifiuti-urbani", "capacita-rinnovabile", "produzione-elettrica-fonti"],
+        "description": "Trasformazioni territoriali, ambiente, energia, rifiuti e sicurezza stradale",
+        "datasets": ["rifiuti-urbani", "capacita-rinnovabile", "produzione-elettrica-fonti", "mit-incidentalita"],
     },
     {
         "slug": "finanza-pubblica",

--- a/src/dataset/mit-incidentalita.md
+++ b/src/dataset/mit-incidentalita.md
@@ -81,12 +81,21 @@ Plot.plot({
 
 ---
 
-## Morti e feriti nel tempo
+## Calo percentuale dal 2001
 
-La riduzione dei morti è stata più rapida di quella dei feriti, segnalando un miglioramento della letalità degli incidenti oltre che della loro frequenza.
+Per confrontare la riduzione di morti e feriti — che hanno scale molto diverse — il grafico mostra la variazione percentuale rispetto al 2001 (base 100). Entrambi gli indicatori sono in forte calo, ma i morti sono diminuiti molto più rapidamente dei feriti (-58% contro -36% al 2018).
 
 ```js
-const mortiFeriti = annuale.flatMap(d => [
+const base2001 = annuale.find(d => d.anno === 2001);
+const indicizzato = annuale.map(d => ({
+  anno: d.anno,
+  incidenti: Math.round(d.incidenti / base2001.incidenti * 100),
+  morti: Math.round(d.morti / base2001.morti * 100),
+  feriti: Math.round(d.feriti / base2001.feriti * 100)
+}));
+
+const trendLines = indicizzato.flatMap(d => [
+  {anno: d.anno, tipo: "Incidenti", valore: d.incidenti},
   {anno: d.anno, tipo: "Morti", valore: d.morti},
   {anno: d.anno, tipo: "Feriti", valore: d.feriti}
 ]);
@@ -94,15 +103,16 @@ const mortiFeriti = annuale.flatMap(d => [
 
 ```js
 Plot.plot({
-  title: "Morti e feriti per anno",
+  title: "Incidenti, morti e feriti — base 2001 = 100",
   width: 800,
   height: 350,
   x: {tickFormat: d => String(d), label: null},
-  y: {grid: true, tickFormat: "~s"},
+  y: {grid: true, label: "% rispetto al 2001"},
   color: {legend: true, scheme: "Set1"},
   marks: [
-    Plot.line(mortiFeriti, {x: "anno", y: "valore", z: "tipo", stroke: "tipo", tip: true}),
-    Plot.dot(mortiFeriti, {x: "anno", y: "valore", z: "tipo", fill: "tipo", r: 1.5})
+    Plot.line(trendLines, {x: "anno", y: "valore", z: "tipo", stroke: "tipo", tip: true}),
+    Plot.dot(trendLines, {x: "anno", y: "valore", z: "tipo", fill: "tipo", r: 1.5}),
+    Plot.ruleY([100], {stroke: "var(--theme-foreground-muted)", strokeDasharray: "4,4"})
   ]
 })
 ```

--- a/src/dataset/mit-incidentalita.md
+++ b/src/dataset/mit-incidentalita.md
@@ -1,0 +1,145 @@
+---
+title: Incidenti stradali
+description: Incidenti stradali, morti e feriti in Italia — serie mensile MIT, 2001-2018
+source: MIT — Ministero delle Infrastrutture e dei Trasporti
+source_url: https://www.mit.gov.it/
+period: "2001–2018"
+last_modified: 2026-06-02
+dataset_slug: mit_incidentalita_mensile
+---
+
+# Incidenti stradali
+
+Serie mensile di incidenti stradali, morti e feriti in Italia. I dati mostrano l'evoluzione della sicurezza stradale dal 2001 al 2018 e gli effetti delle campagne di prevenzione.
+
+**Fonte**: [MIT](https://www.mit.gov.it/) · **Periodo**: 2001–2018 · Dati mensili
+
+```js
+const data = await FileAttachment("../data/mit-incidentalita.json").json();
+```
+
+```js
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const filtered = data.filter(d => d.anno === annoSel);
+const totIncidenti = d3.sum(filtered, d => d.incidenti);
+const totMorti = d3.sum(filtered, d => d.morti);
+const totFeriti = d3.sum(filtered, d => d.feriti);
+```
+
+```js
+// Trend annuale
+const annuale = Array.from(
+  d3.rollup(data, v => ({
+    incidenti: d3.sum(v, d => d.incidenti),
+    morti: d3.sum(v, d => d.morti),
+    feriti: d3.sum(v, d => d.feriti),
+  }), d => d.anno),
+  ([anno, v]) => ({anno, ...v})
+).sort((a, b) => a.anno - b.anno);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Incidenti</h3>
+    <span class="big">${totIncidenti.toLocaleString("it-IT")}</span>
+    <small style="opacity:0.6">${String(annoSel)}</small>
+  </div>
+  <div class="card">
+    <h3>Morti</h3>
+    <span class="big">${totMorti.toLocaleString("it-IT")}</span>
+  </div>
+  <div class="card">
+    <h3>Feriti</h3>
+    <span class="big">${totFeriti.toLocaleString("it-IT")}</span>
+  </div>
+</div>
+
+---
+
+## Trend 2001-2018
+
+Incidenti, morti e feriti sono in costante calo dal 2001. Il miglioramento della sicurezza stradale è visibile su tutti e tre gli indicatori, con una riduzione particolarmente marcata dei morti (-60%).
+
+```js
+Plot.plot({
+  title: "Incidenti stradali in Italia — trend annuale 2001-2018",
+  width: 800,
+  height: 400,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, tickFormat: "~s"},
+  marks: [
+    Plot.lineY(annuale, {x: "anno", y: "incidenti", tip: true, stroke: "#4e79a7"}),
+    Plot.dot(annuale, {x: "anno", y: "incidenti", fill: "#4e79a7", r: 2}),
+    Plot.areaY(annuale, {x: "anno", y: "incidenti", fill: "#4e79a7", fillOpacity: 0.05})
+  ]
+})
+```
+
+---
+
+## Morti e feriti nel tempo
+
+La riduzione dei morti è stata più rapida di quella dei feriti, segnalando un miglioramento della letalità degli incidenti oltre che della loro frequenza.
+
+```js
+const mortiFeriti = annuale.flatMap(d => [
+  {anno: d.anno, tipo: "Morti", valore: d.morti},
+  {anno: d.anno, tipo: "Feriti", valore: d.feriti}
+]);
+```
+
+```js
+Plot.plot({
+  title: "Morti e feriti per anno",
+  width: 800,
+  height: 350,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, tickFormat: "~s"},
+  color: {legend: true, scheme: "Set1"},
+  marks: [
+    Plot.line(mortiFeriti, {x: "anno", y: "valore", z: "tipo", stroke: "tipo", tip: true}),
+    Plot.dot(mortiFeriti, {x: "anno", y: "valore", z: "tipo", fill: "tipo", r: 1.5})
+  ]
+})
+```
+
+---
+
+## Dettaglio mensile
+
+```js
+Inputs.table(filtered, {
+  columns: ["mese", "incidenti", "morti", "feriti", "indice_mortalita", "indice_gravita"],
+  header: {mese: "Mese", incidenti: "Incidenti", morti: "Morti", feriti: "Feriti", indice_mortalita: "Mort.%", indice_gravita: "Grav.%"},
+  format: {
+    incidenti: x => x.toLocaleString("it-IT"),
+    morti: x => x.toLocaleString("it-IT"),
+    feriti: x => x.toLocaleString("it-IT"),
+    indice_mortalita: x => x.toFixed(2) + "%",
+    indice_gravita: x => x.toFixed(2) + "%"
+  },
+  rows: 15,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2001-2018. Dati successivi al 2018 non sono disponibili in questo dataset (la fonte MIT ha cambiato metodologia).
+- **Nazionale**: i dati sono aggregati a livello nazionale. Non è disponibile la disaggregazione regionale o provinciale.
+- **Indicatori**: l'indice di mortalità (morti/incidenti × 100) e l'indice di gravità sono calcolati dal MIT sulla base dei dati mensili.
+- **Metodologia**: la rilevazione degli incidenti stradali ha subito cambiamenti metodologici nel periodo considerato. I dati pre e post 2010 potrebbero non essere perfettamente confrontabili.
+
+---
+
+## Risorse
+
+- [MIT — Open Data](https://www.mit.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/mit_incidentalita_mensile/2001/mit_incidentalita_mensile_2001_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/mit-incidentalita-mensile-2001-2018)

--- a/src/temi/territorio-ambiente.md
+++ b/src/temi/territorio-ambiente.md
@@ -5,7 +5,7 @@ description: Trasformazioni territoriali, ambiente, energia e rifiuti
 
 # Territorio e ambiente
 
-Produzione e raccolta differenziata dei rifiuti urbani, capacità di generazione rinnovabile installata e incidentalità stradale per regione. I dataset di questo tema coprono le trasformazioni ambientali, il mix energetico e la sicurezza stradale in Italia.
+Produzione e raccolta differenziata dei rifiuti urbani, capacità di generazione rinnovabile installata e incidentalità stradale a livello nazionale. I dataset di questo tema coprono le trasformazioni ambientali, il mix energetico e la sicurezza stradale in Italia.
 
 ```js
 const catalog = await FileAttachment("../data/catalog.json").json();

--- a/src/temi/territorio-ambiente.md
+++ b/src/temi/territorio-ambiente.md
@@ -5,7 +5,7 @@ description: Trasformazioni territoriali, ambiente, energia e rifiuti
 
 # Territorio e ambiente
 
-Produzione e raccolta differenziata dei rifiuti urbani, capacità di generazione rinnovabile installata per regione. I dataset di questo tema coprono le trasformazioni ambientali e il mix energetico italiano.
+Produzione e raccolta differenziata dei rifiuti urbani, capacità di generazione rinnovabile installata e incidentalità stradale per regione. I dataset di questo tema coprono le trasformazioni ambientali, il mix energetico e la sicurezza stradale in Italia.
 
 ```js
 const catalog = await FileAttachment("../data/catalog.json").json();


### PR DESCRIPTION
## Cosa

Pagina dataset per **Incidenti stradali MIT** — serie mensile 2001-2018, incidenti, morti, feriti e indicatori di gravità.

### File

- `src/data/mit-incidentalita.json.py` — Loader
- `src/dataset/mit-incidentalita.md` — Pagina standard

### Struttura

1. Cards: incidenti, morti, feriti (anno selezionabile)
2. **Primo blocco**: trend incidenti 2001-2018 (line + area)
3. **Secondo blocco**: morti e feriti in doppia linea
4. Tabella mensile con indicatori di mortalità/gravità

### Tema

**Territorio e ambiente** — sicurezza stradale come impatto territoriale.
