### PR TITLE
feat: link al dashboard SQL in tutte le pagine

### DIFF
--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -173,5 +173,6 @@ Inputs.table(ordinato, {
 ## Risorse
 
 - [BDAP — Open Data (fonte originale)](https://bdap-opendata.rgs.mef.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_lea/2024/bdap_lea_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-lea)

--- a/src/dataset/capacita-rinnovabile.md
+++ b/src/dataset/capacita-rinnovabile.md
@@ -133,6 +133,7 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [Terna (fonte originale)](https://www.terna.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/terna_capacita_rinnovabile/2024/terna_capacita_rinnovabile_2024_clean.parquet)
 - [Analisi](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/terna-electricity-by-source)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/terna-capacita-rinnovabile)

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -149,5 +149,6 @@ Inputs.table(regFiltered, {
 ## Risorse
 
 - [Consip — Dati (fonte originale)](https://dati.consip.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/consip_consumi_convenzione/2025/consip_consumi_convenzione_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/consip-consumi-convenzione)

--- a/src/dataset/dipendenti-pubblici.md
+++ b/src/dataset/dipendenti-pubblici.md
@@ -135,6 +135,7 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [MEF · RGS · BDAP (fonte originale)](https://www.rgs.mef.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/dipendenti_pubblici/2023/dipendenti_pubblici_2023_clean.parquet)
 - [Analisi](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/dipendenti-pubblici)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/dipendenti-pubblici)

--- a/src/dataset/entrate-stato.md
+++ b/src/dataset/entrate-stato.md
@@ -122,5 +122,6 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [RGS · BDAP (fonte originale)](https://bdap.rgs.mef.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_entrate_stato/2024/bdap_entrate_stato_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-entrate-stato)

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -157,6 +157,7 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [Ministero della Giustizia (fonte originale)](https://datiestatistiche.giustizia.it)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/civile_flussi/2025/civile_flussi_2025_clean.parquet)
 - [Analisi completa](https://github.com/dataciviclab/dataciviclab/tree/main/analisi/civile-flussi)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/civile-flussi)

--- a/src/dataset/housing-crowding.md
+++ b/src/dataset/housing-crowding.md
@@ -137,5 +137,6 @@ Inputs.table(trend, {
 ## Risorse
 
 - [ISTAT — Esplora dati](https://esploradati.istat.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_housing_crowding/2024/istat_housing_crowding_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-housing-crowding)

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -199,6 +199,7 @@ Inputs.table(capConMedia, {
 ## Risorse
 
 - [MEF — Dipartimento delle Finanze (fonte originale)](https://www1.finanze.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/irpef_comunale/2023/irpef_comunale_2023_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/irpef-comunale)
 <!-- Analisi non ancora pubblicata. Quando sarà disponibile, aggiungere:

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -184,5 +184,6 @@ Inputs.table(annoConDelta, {
 ## Risorse
 
 - [ISTAT — Esplora dati](https://esploradati.istat.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_gini_regionale/2023/istat_gini_regionale_2023_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-gini-regionale)

--- a/src/dataset/istat-ipab-aree.md
+++ b/src/dataset/istat-ipab-aree.md
@@ -127,5 +127,6 @@ Inputs.table(ultimiValori, {
 ## Risorse
 
 - [ISTAT — IPAB (fonte originale)](https://www.istat.it/it/archivio/16773)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/istat_ipab_aree/2024/istat_ipab_aree_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/istat-ipab-aree)

--- a/src/dataset/mim-alunni-corso-eta.md
+++ b/src/dataset/mim-alunni-corso-eta.md
@@ -173,5 +173,6 @@ Inputs.table(pivot, {
 ## Risorse
 
 - [MIM — Dati istruzione](https://dati.istruzione.it/opendata/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/mim_alunni_corso_eta/2025/mim_alunni_corso_eta_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/mim-alunni-corso-eta)

--- a/src/dataset/mit-incidentalita.md
+++ b/src/dataset/mit-incidentalita.md
@@ -151,5 +151,6 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [MIT — Open Data](https://www.mit.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/mit_incidentalita_mensile/2001/mit_incidentalita_mensile_2001_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/mit-incidentalita-mensile-2001-2018)

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -183,5 +183,6 @@ Inputs.table(perRegione, {
 ## Risorse
 
 - [OpenCivitas (fonte originale)](https://www.opencivitas.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/opencivitas_fsc_2025_rso/2025/opencivitas_fsc_2025_rso_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/opencivitas-fsc-2025-rso)

--- a/src/dataset/pensioni-inps.md
+++ b/src/dataset/pensioni-inps.md
@@ -129,5 +129,6 @@ Inputs.table(perGestione, {
 ## Risorse
 
 - [INPS Open Data (fonte originale)](https://www.inps.it/open-data)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/inps_pensioni_trimestrale/2024/inps_pensioni_trimestrale_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/inps-pensioni)

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -185,5 +185,6 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [ISTAT — Esplora dati](https://esploradati.istat.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/popolazione_istat_comunale_2019_2025/2025/popolazione_istat_comunale_2019_2025_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/popolazione-istat-comunale-2019-2025)

--- a/src/dataset/produzione-elettrica-fonti.md
+++ b/src/dataset/produzione-elettrica-fonti.md
@@ -157,6 +157,7 @@ Inputs.table(filtered, {
 ## Risorse
 
 - [Terna (fonte originale)](https://www.terna.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/terna_electricity_by_source/2024/terna_electricity_by_source_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/terna-electricity-by-source)
 <!-- - [Analisi](/analisi/terna-electricity-by-source) -->

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -164,5 +164,6 @@ Inputs.table(regFiltered, {
 ## Risorse
 
 - [ISPRA — Rifiuti Urbani (fonte originale)](https://www.isprambiente.gov.it/it/dati/dati-sui-rifiuti-urbani)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/ispra_ru_base/2024/ispra_ru_base_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/ispra-ru-base)

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -156,5 +156,6 @@ Inputs.table(perRegione, {
 ## Risorse
 
 - [AIFA — Open Data (fonte originale)](https://www.aifa.gov.it/open-data)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/aifa_spesa_consumo/2024/aifa_spesa_consumo_2024_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/aifa-spesa-consumo)

--- a/src/dataset/votazioni-camera.md
+++ b/src/dataset/votazioni-camera.md
@@ -188,5 +188,6 @@ Inputs.table(filtered2, {
 ## Risorse
 
 - [Camera dei Deputati — Dati aperti](https://dati.camera.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
 - [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/camera_votazioni_sparql/2025/camera_votazioni_sparql_2025_clean.parquet)
 - [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/camera-votazioni-sparql)


### PR DESCRIPTION
## Cosa

Aggiunto link al Query SQL Dashboard in tutte le 19 pagine dataset, prima del link al parquet pulito.

### Perché

- Il dashboard dà accesso a tutta la serie storica, non solo all'ultimo anno
- Più accessibile per utenti non tecnici
- Il parquet resta come link secondario

### Struttura risorse

```markdown
- [Fonte originale](...)
- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
- [Scarica il parquet pulito](...)
- [Pipeline](...)
```
