### PR TITLE
ci: paths filter + pip cache per PR check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/data/**'
+      - 'src/dataset/**'
+      - 'src/temi/**'
+      - 'observablehq.config.js'
+      - '.github/workflows/pr-check.yml'
 
 permissions:
   contents: read
@@ -27,6 +33,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
 
       - run: npm ci --legacy-peer-deps
       - run: pip install -r requirements.txt


### PR DESCRIPTION
## Cosa

Ottimizzazione del workflow PR check per ridurre i tempi di esecuzione.

### Modifiche

1. **`paths` filter** — il workflow parte solo quando vengono modificati file rilevanti:
   - `src/data/**` — data loader Python
   - `src/dataset/**` — pagine dataset
   - `src/temi/**` — pagine tema
   - `observablehq.config.js` — configurazione sidebar
   - `.github/workflows/pr-check.yml` — workflow stesso

   PR che toccano solo README, CONTRIBUTING, docs/ **non attivano CI** (0 minuti).

2. **`cache: pip`** in `setup-python` — cache delle dipendenze Python tra run, risparmia ~20s.

### Effetto

| Scenario | Prima | Dopo |
|---|---|---|
| PR docs-only | 4 min (inutili) | **0 min** |
| PR dati/loader | ~4 min | ~3 min 40s |
