### PR TITLE
feat(consumo-suolo): stock cementificazione per regione — ISPRA 2024

### DIFF
--- a/src/data/consumo-suolo.json.py
+++ b/src/data/consumo-suolo.json.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Data loader: ISPRA consumo suolo — aggregazione regionale.
+Stock% usa AVG, gli altri usano SUM.
+Loader custom perche' load_dataset() usa SUM su tutte le metriche."""
+import json, sys
+sys.path.insert(0, "src/data")
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.paths import https_url
+
+slug = "ispra_consumo_suolo"
+year = 2024
+
+if not object_exists("dataciviclab-clean", f"{slug}/{year}/{slug}_{year}_clean.parquet"):
+    json.dump([], sys.stdout)
+    sys.exit(0)
+
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT regione,
+               AVG(stock_pct_2024) AS stock_pct_2024,
+               SUM(stock_ha_2024) AS stock_ha_2024,
+               SUM(incremento_netto_ha_2023_2024) AS incremento_netto_ha_2023_2024,
+               SUM(incremento_lordo_ha_2023_2024) AS incremento_lordo_ha_2023_2024
+        FROM read_parquet('{https_url("clean", "clean_parquet", slug=slug, year=year)}')
+        WHERE regione IS NOT NULL AND regione != ''
+        GROUP BY regione
+        ORDER BY regione
+    """).fetchall()
+
+data = [
+    {"regione": r[0], "stock_pct_2024": float(r[1]), "stock_ha_2024": float(r[2]),
+     "incremento_netto_ha_2023_2024": float(r[3]), "incremento_lordo_ha_2023_2024": float(r[4])}
+    for r in rows
+]
+
+json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -6,8 +6,8 @@ themes = [
     {
         "slug": "territorio-ambiente",
         "name": "Territorio e ambiente",
-        "description": "Trasformazioni territoriali, ambiente, energia, rifiuti e sicurezza stradale",
-        "datasets": ["rifiuti-urbani", "capacita-rinnovabile", "produzione-elettrica-fonti", "mit-incidentalita"],
+        "description": "Trasformazioni territoriali, ambiente, energia, rifiuti, consumo di suolo e sicurezza stradale",
+        "datasets": ["rifiuti-urbani", "capacita-rinnovabile", "produzione-elettrica-fonti", "mit-incidentalita", "consumo-suolo"],
     },
     {
         "slug": "finanza-pubblica",

--- a/src/dataset/consumo-suolo.md
+++ b/src/dataset/consumo-suolo.md
@@ -1,0 +1,126 @@
+---
+title: Consumo di suolo
+description: Consumo di suolo per regione — stock e incremento annuale, ISPRA 2024
+source: ISPRA
+source_url: https://www.isprambiente.gov.it/
+period: "2024"
+last_modified: 2026-06-03
+dataset_slug: ispra_consumo_suolo
+---
+
+# Consumo di suolo
+
+Stock di suolo consumato e incremento netto annuale per regione. I dati ISPRA mostrano la cementificazione del territorio e la sua distribuzione geografica.
+
+**Fonte**: [ISPRA](https://www.isprambiente.gov.it/) · **Periodo**: 2024
+
+```js
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, numFix, tableFormat } from "../import/format-utils.js";
+```
+
+```js
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
+```
+
+```js
+const data = await FileAttachment("../data/consumo-suolo.json").json();
+```
+
+```js
+const ordinato = [...data].sort((a, b) => b.stock_pct_2024 - a.stock_pct_2024);
+const mediaNaz = d3.mean(data, d => d.stock_pct_2024);
+const totHa = d3.sum(data, d => d.stock_ha_2024);
+const totInc = d3.sum(data, d => d.incremento_netto_ha_2023_2024);
+```
+
+```js
+// Lookup con fallback automatici per match TopoJSON
+const stockLookup = buildRegLookup(data, "regione", "stock_pct_2024");
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Suolo consumato</h3>
+    <span class="big">${numFix(mediaNaz, 1)}%</span>
+    <small style="opacity:0.6">media regionale</small>
+  </div>
+  <div class="card">
+    <h3>Stock totale</h3>
+    <span class="big">${(totHa / 1000).toFixed(0)} <small style="opacity:0.6">k ha</small></span>
+  </div>
+  <div class="card">
+    <h3>Incremento 2023-24</h3>
+    <span class="big">${num(totInc)} <small style="opacity:0.6">ha</small></span>
+  </div>
+</div>
+
+---
+
+## Stock suolo consumato per regione
+
+Quali regioni hanno più suolo consumato? La percentuale di territorio cementificato è molto più alta in Lombardia e Veneto, mentre Basilicata e Valle d'Aosta registrano i valori più bassi.
+
+```js
+Plot.plot({
+  title: "Stock suolo consumato per regione — 2024",
+  projection: {type: "mercator", domain: regioniGeo},
+  width: 800,
+  height: 600,
+  color: {scheme: "Reds", legend: true, label: "% suolo consumato", type: "quantile"},
+  marks: [
+    Plot.geo(regioniGeo, {
+      fill: d => stockLookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#888",
+      strokeWidth: 0.25,
+      tip: {format: {fill: d => numFix(d, 1) + "%"}}
+    }),
+    Plot.geo(confiniReg, {
+      stroke: "#888",
+      strokeWidth: 0.7
+    })
+  ]
+})
+```
+
+---
+
+## Dettaglio regioni
+
+```js
+const { header, format } = tableFormat({
+  regione: { label: "Regione", fmt: "string" },
+  stock_pct_2024: { label: "Stock %", fmt: "pct" },
+  stock_ha_2024: { label: "Stock (ha)", fmt: "num" },
+  incremento_netto_ha_2023_2024: { label: "Incr. 23-24 (ha)", fmt: "num" },
+});
+```
+
+```js
+Inputs.table(ordinato, {
+  columns: ["regione", "stock_pct_2024", "stock_ha_2024", "incremento_netto_ha_2023_2024"],
+  header,
+  format,
+  rows: 25,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: il dataset copre il solo 2024. Dati precedenti non sono disponibili in questo dataset (le serie storiche sono disponibili nel dato originale ISPRA).
+- **Stock**: la percentuale di suolo consumato è calcolata sul territorio comunale. I valori regionali sono medie dei comuni, non ponderate per superficie.
+- **Incremento netto**: differenza tra consumo lordo e ripristino nell'ultimo periodo disponibile (2023-2024).
+- **Fonte**: i dati provengono da ISPRA — monitoraggio del consumo di suolo.
+
+---
+
+## Risorse
+
+- [ISPRA — Consumo di suolo](https://www.isprambiente.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/ispra_consumo_suolo/2024/ispra_consumo_suolo_2024_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/ispra-consumo-suolo)


### PR DESCRIPTION
## Chiusa — dataset da migliorare in DI prima di pubblicare in explorer

Il dataset `ispra_consumo_suolo` ha le metriche di incremento modellate in formato wide (37 colonne anno-su-anno), che rende la pagina thin (solo 2024). 

**Decisione**: teniamo il candidato in DI come `incubating` e lo ripubblichiamo quando la pipeline farà il pivot wide→long. A quel punto la pagina potrà mostrare trend storici e analisi più ricche.

Vedi la discussione nel thread per i dettagli.
