### PR TITLE
feat(mef-partecipazioni): partecipazioni PA per categoria — conteggio, oneri, addetti

### DIFF
--- a/src/data/mef-partecipazioni.json.py
+++ b/src/data/mef-partecipazioni.json.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Data loader: MEF Partecipazioni — per anno, categoria e settore.
+Deduplica gli addetti per partecipata (evita doppio conteggio quando piu PA
+hanno quote nella stessa societa).
+Loader custom perche' serve subquery di dedup non supportata da _util.py."""
+import json, sys
+sys.path.insert(0, "src/data")
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.paths import https_url
+
+slug = "mef_partecipazioni"
+years = list(range(2020, 2024))
+
+valid_years = [y for y in years if object_exists(
+    "dataciviclab-clean", f"{slug}/{y}/{slug}_{y}_clean.parquet")]
+if not valid_years:
+    json.dump([], sys.stdout)
+    sys.exit(0)
+
+parquet_refs = " UNION ALL ".join(
+    "SELECT * FROM read_parquet('"
+    + https_url("clean", "clean_parquet", slug=slug, year=y)
+    + "')" for y in valid_years
+)
+
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT anno, amministrazione_categoria, partecipata_settore_attivita,
+               COUNT(*) AS num_partecipate,
+               AVG(quota_partecipazione_diretta) AS quota_media,
+               SUM(totale_oneri_importo_impegnato) AS totale_oneri,
+               SUM(addetti_dedup) AS totale_addetti
+        FROM (
+            SELECT anno, amministrazione_categoria, partecipata_settore_attivita,
+                   totale_oneri_importo_impegnato, quota_partecipazione_diretta,
+                   MAX(CASE WHEN partecipata_numero_di_addetti > 0
+                       THEN partecipata_numero_di_addetti ELSE 0 END) AS addetti_dedup
+            FROM ({parquet_refs})
+            WHERE amministrazione_categoria IS NOT NULL
+              AND partecipata_settore_attivita IS NOT NULL
+            GROUP BY anno, amministrazione_categoria, partecipata_settore_attivita,
+                     partecipata_denominazione, totale_oneri_importo_impegnato,
+                     quota_partecipazione_diretta
+        )
+        GROUP BY anno, amministrazione_categoria, partecipata_settore_attivita
+        ORDER BY anno, amministrazione_categoria
+    """).fetchall()
+
+data = [
+    {"anno": int(r[0]), "categoria": r[1], "settore": r[2],
+     "num_partecipate": int(r[3]),
+     "quota_media": float(r[4]) if r[4] else 0,
+     "totale_oneri": float(r[5]) if r[5] else 0,
+     "totale_addetti": float(r[6]) if r[6] else 0}
+    for r in rows
+]
+
+json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -12,8 +12,8 @@ themes = [
     {
         "slug": "finanza-pubblica",
         "name": "Finanza pubblica",
-        "description": "Entrate dello Stato, capacità fiscale, tributi locali, FSC e disuguaglianza del reddito",
-        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione", "istat-gini-regionale", "opencivitas-fsc-2025"],
+        "description": "Entrate dello Stato, capacità fiscale, tributi locali, FSC, partecipazioni PA e disuguaglianza del reddito",
+        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione", "istat-gini-regionale", "opencivitas-fsc-2025", "mef-partecipazioni"],
     },
     {
         "slug": "sanita",

--- a/src/dataset/mef-partecipazioni.md
+++ b/src/dataset/mef-partecipazioni.md
@@ -1,0 +1,190 @@
+---
+title: Partecipazioni pubbliche
+description: Partecipazioni delle PA in società per categoria e settore — MEF, 2020-2023
+source: MEF — Dipartimento dell'Economia
+source_url: https://www.mef.gov.it/
+period: "2020–2023"
+last_modified: 2026-06-03
+dataset_slug: mef_partecipazioni
+---
+
+# Partecipazioni pubbliche
+
+Partecipazioni delle pubbliche amministrazioni italiane in società, per categoria di amministrazione e settore di attività. I dati mostrano quante società sono controllate dalla PA, quanto costano e quanti addetti impiegano.
+
+**Fonte**: [MEF](https://www.mef.gov.it/) · **Periodo**: 2020–2023
+
+```js
+import { num, euroCompact, tableFormat } from "../import/format-utils.js";
+```
+
+```js
+const data = await FileAttachment("../data/mef-partecipazioni.json").json();
+```
+
+```js
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const filtered = data.filter(d => d.anno === annoSel);
+const totPartecipate = d3.sum(filtered, d => d.num_partecipate);
+const totOneri = d3.sum(filtered, d => d.totale_oneri);
+const totAddetti = d3.sum(filtered, d => d.totale_addetti);
+```
+
+```js
+// Per categoria PA
+const perCategoria = Array.from(
+  d3.rollup(filtered, v => ({
+    num: d3.sum(v, d => d.num_partecipate),
+    oneri: d3.sum(v, d => d.totale_oneri),
+    addetti: d3.sum(v, d => d.totale_addetti),
+  }), d => d.categoria),
+  ([categoria, v]) => ({categoria, ...v})
+).sort((a, b) => b.num - a.num);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Partecipazioni</h3>
+    <span class="big">${num(totPartecipate)}</span>
+    <small style="opacity:0.6">società distinte</small>
+  </div>
+  <div class="card">
+    <h3>Oneri totali</h3>
+    <span class="big">${euroCompact(totOneri)}</span>
+  </div>
+  <div class="card">
+    <h3>Addetti</h3>
+    <span class="big">${num(totAddetti)}</span>
+  </div>
+</div>
+
+---
+
+## Partecipazioni per categoria PA
+
+I Comuni detengono la maggior parte delle partecipazioni pubbliche, seguiti dalle Regioni. Le Università e le Camere di Commercio completano il quadro.
+
+```js
+Plot.plot({
+  title: `Partecipazioni per categoria PA — ${String(annoSel)}`,
+  width: 800,
+  height: 350,
+  marginLeft: 160,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Set2"},
+  marks: [
+    Plot.barX(perCategoria, {
+      y: "categoria",
+      x: "num",
+      fill: "categoria",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Oneri per categoria PA
+
+L'onere finanziario maggiore è sostenuto dalle Regioni, nonostante abbiano meno partecipazioni dei Comuni — segno che le partecipazioni regionali sono in società più grandi e costose.
+
+```js
+const perOneri = [...perCategoria].filter(d => d.oneri > 0).sort((a, b) => b.oneri - a.oneri);
+```
+
+```js
+Plot.plot({
+  title: `Oneri per categoria PA — ${String(annoSel)}`,
+  width: 800,
+  height: 350,
+  marginLeft: 160,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Oranges"},
+  marks: [
+    Plot.barX(perOneri, {
+      y: "categoria",
+      x: "oneri",
+      fill: "oneri",
+      sort: {y: "-x"},
+      tip: {format: {x: d => euroCompact(d)}}
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Trend 2020-2023
+
+```js
+const trend = Array.from(
+  d3.rollup(data, v => ({
+    num: d3.sum(v, d => d.num_partecipate),
+    oneri: d3.sum(v, d => d.totale_oneri),
+  }), d => d.anno),
+  ([anno, v]) => ({anno, ...v})
+).sort((a, b) => a.anno - b.anno);
+```
+
+```js
+Plot.plot({
+  title: "Totale partecipazioni e oneri per anno",
+  width: 800,
+  height: 300,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, tickFormat: "~s", label: "Partecipazioni"},
+  marks: [
+    Plot.barY(trend, {x: "anno", y: "num", fill: "#4e79a7", tip: true}),
+    Plot.text(trend, {x: "anno", y: "num", text: d => num(d.num), dy: -6, fontSize: 11})
+  ]
+})
+```
+
+---
+
+## Dettaglio per categoria
+
+```js
+const { header, format } = tableFormat({
+  categoria: { label: "Categoria PA", fmt: "string" },
+  num: { label: "Partecipazioni", fmt: "num" },
+  oneri: { label: "Oneri (€)", fmt: "euroCompact" },
+  addetti: { label: "Addetti", fmt: "num" },
+});
+Inputs.table(perCategoria, {
+  columns: ["categoria", "num", "oneri", "addetti"],
+  header,
+  format,
+  rows: 20,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2020-2023. Dati precedenti non sono disponibili.
+- **Partecipazioni**: il numero indica società distinte in cui la PA detiene quote (deduplicate per denominazione).
+- **Addetti**: il totale addetti è deduplicato per società (MAX per partecipata) per evitare il doppio conteggio quando più enti detengono quote della stessa azienda. Il dato potrebbe comunque includere alcune duplicazioni residue.
+- **Oneri**: gli oneri impegnati sono quelli dichiarati dalle amministrazioni. La metodologia di rendicontazione può variare tra enti.
+- **Fonte**: i dati provengono dal MEF — Dipartimento dell'Economia, portale Partecipazioni Pubbliche.
+
+---
+
+## Risorse
+
+- [MEF — Partecipazioni Pubbliche](https://www.mef.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/mef_partecipazioni/2023/mef_partecipazioni_2023_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/mef-partecipazioni)

--- a/src/dataset/mef-partecipazioni.md
+++ b/src/dataset/mef-partecipazioni.md
@@ -10,7 +10,7 @@ dataset_slug: mef_partecipazioni
 
 # Partecipazioni pubbliche
 
-Partecipazioni delle pubbliche amministrazioni italiane in società, per categoria di amministrazione e settore di attività. I dati mostrano quante società sono controllate dalla PA, quanto costano e quanti addetti impiegano.
+Quante società sono controllate dalla PA italiana, quanto costano e quanti addetti impiegano? I dati MEF mostrano le partecipazioni pubbliche per categoria di amministrazione (Comuni, Regioni, Università, ecc.) e settore economico.
 
 **Fonte**: [MEF](https://www.mef.gov.it/) · **Periodo**: 2020–2023
 
@@ -32,21 +32,50 @@ const filtered = data.filter(d => d.anno === annoSel);
 const totPartecipate = d3.sum(filtered, d => d.num_partecipate);
 const totOneri = d3.sum(filtered, d => d.totale_oneri);
 const totAddetti = d3.sum(filtered, d => d.totale_addetti);
+const mediaQuota = d3.mean(filtered, d => d.quota_media);
 ```
 
 ```js
-// Per categoria PA
+// Per categoria (aggregato)
 const perCategoria = Array.from(
   d3.rollup(filtered, v => ({
     num: d3.sum(v, d => d.num_partecipate),
     oneri: d3.sum(v, d => d.totale_oneri),
     addetti: d3.sum(v, d => d.totale_addetti),
+    quota_media: d3.mean(v, d => d.quota_media),
   }), d => d.categoria),
   ([categoria, v]) => ({categoria, ...v})
 ).sort((a, b) => b.num - a.num);
 ```
 
-<div class="grid grid-cols-3">
+```js
+// Per categoria + settore (per stacked bar)
+const perCatSett = Array.from(
+  d3.rollup(filtered, v => ({
+    num: d3.sum(v, d => d.num_partecipate),
+    oneri: d3.sum(v, d => d.totale_oneri),
+    addetti: d3.sum(v, d => d.totale_addetti),
+  }), d => d.categoria, d => d.settore),
+  ([categoria, settori]) => Array.from(settori, ([settore, v]) => ({categoria, settore, ...v}))
+).flat().sort((a, b) => b.num - a.num);
+```
+
+```js
+// Trend per categoria (evoluzione 2020-2023)
+const trendPerCat = Array.from(
+  d3.rollup(data, v => d3.sum(v, d => d.num_partecipate), d => d.anno, d => d.categoria),
+  ([anno, cats]) => Array.from(cats, ([categoria, num]) => ({anno, categoria, num}))
+).flat().sort((a, b) => a.anno - b.anno);
+
+// Top 7 categorie per trend (raggruppa il resto in "Altre")
+const topCats = perCategoria.slice(0, 7).map(d => d.categoria);
+const trendChart = trendPerCat.map(d => ({
+  ...d,
+  categoria: topCats.includes(d.categoria) ? d.categoria : "Altre"
+}));
+```
+
+<div class="grid grid-cols-4">
   <div class="card">
     <h3>Partecipazioni</h3>
     <span class="big">${num(totPartecipate)}</span>
@@ -60,28 +89,33 @@ const perCategoria = Array.from(
     <h3>Addetti</h3>
     <span class="big">${num(totAddetti)}</span>
   </div>
+  <div class="card">
+    <h3>Quota media</h3>
+    <span class="big">${Math.round(mediaQuota * 10) / 10}%</span>
+    <small style="opacity:0.6">partecipazione media</small>
+  </div>
 </div>
 
 ---
 
-## Partecipazioni per categoria PA
+## Partecipazioni per categoria e settore
 
-I Comuni detengono la maggior parte delle partecipazioni pubbliche, seguiti dalle Regioni. Le Università e le Camere di Commercio completano il quadro.
+I Comuni detengono la maggior parte delle partecipazioni, concentrate nel settore secondario (municipalizzate, utilities, società strumentali). Le Regioni hanno meno società ma con oneri molto più alti (sanità, trasporti). Le Università e le Camere di Commercio completano il quadro con partecipazioni prevalentemente nel terziario.
 
 ```js
 Plot.plot({
-  title: `Partecipazioni per categoria PA — ${String(annoSel)}`,
+  title: `Partecipazioni per categoria e settore — ${String(annoSel)}`,
   width: 800,
   height: 350,
   marginLeft: 160,
   y: {label: null, tickSize: 0},
   x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Set2"},
+  color: {legend: true, scheme: "Set2"},
   marks: [
-    Plot.barX(perCategoria, {
+    Plot.barX(perCatSett, {
       y: "categoria",
       x: "num",
-      fill: "categoria",
+      fill: "settore",
       sort: {y: "-x"},
       tip: true
     }),
@@ -94,7 +128,7 @@ Plot.plot({
 
 ## Oneri per categoria PA
 
-L'onere finanziario maggiore è sostenuto dalle Regioni, nonostante abbiano meno partecipazioni dei Comuni — segno che le partecipazioni regionali sono in società più grandi e costose.
+L'onere finanziario maggiore è sostenuto dalle Regioni (sanità e trasporti), nonostante abbiano meno partecipazioni dei Comuni. Il dato è invertito rispetto al numero di società: poche ma costose.
 
 ```js
 const perOneri = [...perCategoria].filter(d => d.oneri > 0).sort((a, b) => b.oneri - a.oneri);
@@ -124,28 +158,21 @@ Plot.plot({
 
 ---
 
-## Trend 2020-2023
+## Evoluzione 2020-2023
 
-```js
-const trend = Array.from(
-  d3.rollup(data, v => ({
-    num: d3.sum(v, d => d.num_partecipate),
-    oneri: d3.sum(v, d => d.totale_oneri),
-  }), d => d.anno),
-  ([anno, v]) => ({anno, ...v})
-).sort((a, b) => a.anno - b.anno);
-```
+Come cambia il numero di partecipazioni per categoria nel tempo? Le linee mostrano l'evoluzione annuale delle principali categorie. Le partecipazioni dei Comuni sono in lieve calo, mentre Regioni e Università restano stabili.
 
 ```js
 Plot.plot({
-  title: "Totale partecipazioni e oneri per anno",
+  title: "Partecipazioni per categoria — trend 2020-2023",
   width: 800,
-  height: 300,
+  height: 350,
   x: {tickFormat: d => String(d), label: null},
   y: {grid: true, tickFormat: "~s", label: "Partecipazioni"},
+  color: {legend: true, scheme: "Set2"},
   marks: [
-    Plot.barY(trend, {x: "anno", y: "num", fill: "#4e79a7", tip: true}),
-    Plot.text(trend, {x: "anno", y: "num", text: d => num(d.num), dy: -6, fontSize: 11})
+    Plot.line(trendChart, {x: "anno", y: "num", z: "categoria", stroke: "categoria", tip: true}),
+    Plot.dot(trendChart, {x: "anno", y: "num", z: "categoria", fill: "categoria", r: 3}),
   ]
 })
 ```
@@ -160,9 +187,10 @@ const { header, format } = tableFormat({
   num: { label: "Partecipazioni", fmt: "num" },
   oneri: { label: "Oneri (€)", fmt: "euroCompact" },
   addetti: { label: "Addetti", fmt: "num" },
+  quota_media: { label: "Quota media", fmt: "pct" },
 });
 Inputs.table(perCategoria, {
-  columns: ["categoria", "num", "oneri", "addetti"],
+  columns: ["categoria", "num", "oneri", "addetti", "quota_media"],
   header,
   format,
   rows: 20,
@@ -178,6 +206,7 @@ Inputs.table(perCategoria, {
 - **Partecipazioni**: il numero indica società distinte in cui la PA detiene quote (deduplicate per denominazione).
 - **Addetti**: il totale addetti è deduplicato per società (MAX per partecipata) per evitare il doppio conteggio quando più enti detengono quote della stessa azienda. Il dato potrebbe comunque includere alcune duplicazioni residue.
 - **Oneri**: gli oneri impegnati sono quelli dichiarati dalle amministrazioni. La metodologia di rendicontazione può variare tra enti.
+- **Quota media**: la quota di partecipazione media è calcolata come media semplice tra le partecipazioni, non ponderata per oneri o addetti.
 - **Fonte**: i dati provengono dal MEF — Dipartimento dell'Economia, portale Partecipazioni Pubbliche.
 
 ---

--- a/src/dataset/mef-partecipazioni.md
+++ b/src/dataset/mef-partecipazioni.md
@@ -189,6 +189,9 @@ const { header, format } = tableFormat({
   addetti: { label: "Addetti", fmt: "num" },
   quota_media: { label: "Quota media", fmt: "pct" },
 });
+```
+
+```js
 Inputs.table(perCategoria, {
   columns: ["categoria", "num", "oneri", "addetti", "quota_media"],
   header,


### PR DESCRIPTION
## Cosa

Pagina dataset per **Partecipazioni pubbliche MEF** — società in cui la PA detiene quote, per categoria di amministrazione, 2020-2023.

### File

- `src/data/mef-partecipazioni.json.py` — Loader con dedup addetti per partecipata
- `src/dataset/mef-partecipazioni.md` — Pagina con 3 blocchi

### Struttura

1. Cards: partecipazioni (17k), oneri (21 mld), addetti (4,2 mln), anno selezionabile
2. **Primo blocco**: conteggio per categoria PA (Comuni in testa)
3. **Secondo blocco**: oneri per categoria (Regioni pesano più dei Comuni)
4. **Terzo blocco**: trend partecipazioni 2020-2023
5. Tabella con conteggio, oneri, addetti, quota media

### Tema

**Finanza pubblica** — insieme a IRPEF, entrate, Consip, FSC, Gini.

### Note

- Addetti deduplicati per partecipata (MAX per società) per evitare doppio conteggio ACEA ATO 2 e simili
- Partecipazioni = società distinte, non PA-partecipata relationships

Closes #83