### PR TITLE
refactor: update lab-connectors@v0.12.0, org-level action, cache pip in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,8 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Install Python dependencies
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - run: pip install -r requirements.txt
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
 
       - name: Check data loaders exist
         run: echo "data loader check bypassed — i loader sono manuali e tracciati in git"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -30,14 +30,12 @@ jobs:
           node-version: "20"
           cache: npm
 
-      - uses: actions/setup-python@v6
+      - name: Python setup
+        uses: dataciviclab/.github/actions/python-setup@main
         with:
-          python-version: "3.12"
-          cache: pip
+          extra-packages: pytest-cov
 
       - run: npm ci --legacy-peer-deps
-      - run: pip install -r requirements.txt
-      - run: pip install pytest-cov  # per coverage:py
 
       - name: Lint
         run: npm run lint

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests>=2.28.0
 pyyaml>=6.0
 
 # Path contract GCS — vedere lab-connectors/gcs/paths.py
-lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.9.0
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.12.0


### PR DESCRIPTION
## Sintesi

Allinea data-explorer alla nuova infrastruttura condivisa: lab-connectors v0.12.0, org-level action, cache pip in deploy.

## Cosa cambia

- [ ] Dipendenze o CI

## Impatto

- [x] Nessun impatto su interfacce pubbliche

## Dettaglio

- Aggiorna lab-connectors: v0.9.0 → v0.12.0 (4 versioni di gap)
- pr-check.yml: switch setup Python a `dataciviclab/.github/actions/python-setup@main` (con cache pip)
- deploy.yml: switch setup Python a org-level action — **aggiunge cache pip che prima mancava**

## Verifica

```
npm run lint  → pass
```
