### PR TITLE
feat: moduli condivisi geo-utils + format-utils, refactor pagine con mappe, doc allineati

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,8 @@ on:
       - 'src/data/**'
       - 'src/dataset/**'
       - 'src/temi/**'
+      - 'src/import/**'
+      - 'tests/**'
       - 'observablehq.config.js'
       - '.github/workflows/pr-check.yml'
 
@@ -18,6 +20,10 @@ permissions:
 concurrency:
   group: pr-check-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
+env:
+  # Disabilita telemetry OF in CI
+  OBSERVABLE_TELEMETRY_DISABLED: 1
 
 jobs:
   test:
@@ -37,6 +43,16 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
 
+      # Cache OF data loader output: se i .json.py non cambiano,
+      # OF usa la cache invece di rieseguire i loader (DuckDB + GCS).
+      # Chiave: hash dei file .json.py in src/data/.
+      - name: Cache Observable Framework build
+        id: cache-of
+        uses: actions/cache@v4
+        with:
+          path: src/.observablehq/cache
+          key: of-cache-${{ hashFiles('src/data/*.json.py', 'src/data/_util.py', 'src/data/catalog.json.py', 'src/data/themes.json.py') }}
+
       - name: Lint
         run: npm run lint
 
@@ -48,3 +64,5 @@ jobs:
 
       - name: Build
         run: npx observable build
+        # Se la cache OF ha fatto match, i data loader vengono saltati
+        # e il build usa solo i JSON in cache + bundle JS (~30s).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,9 @@ Apri http://localhost:3000
    in `src/dataset/<slug-url>.md` e compila ogni sezione
    - frontmatter obbligatorio: `title`, `description`, `source`, `source_url`, `period`,
      `last_modified`, `dataset_slug`
+   - usa i **moduli condivisi** in `src/import/` per non replicare boilerplate:
+     - `geo-utils.js` per mappe, normalizzazione regioni e lookup geografici
+     - `format-utils.js` per formattazione numeri, valute, percentuali e tabelle
    - primo blocco: distribuzione o stock base, non ranking o delta
    - sezione **Limiti** obbligatoria in fondo (copertura, granularità, note metodologiche)
    - vedi `docs/dataset-page-standard.md` per i principi guida
@@ -46,7 +49,24 @@ Apri http://localhost:3000
 4. **Tema**: se il dataset introduce un nuovo tema, aggiungilo in `src/data/themes.json.py`
 5. **Verifica** con `npm run dev` che la pagina sia navigabile e i dati si carichino
 6. **Checklist pre-pub** (nel template, in fondo): verificare slug, parquet, frontmatter,
-   leggibilità, link funzionanti
+   uso moduli condivisi, leggibilità, link funzionanti
+
+### Moduli condivisi (`src/import/`)
+
+I moduli in `src/import/` centralizzano boilerplate che altrimenti andrebbe riscritto in ogni pagina:
+
+| Modulo | Funzioni principali | Quando usarlo |
+|--------|-------------------|---------------|
+| `geo-utils.js` | `normalizzaReg()`, `loadItalianRegions()`, `buildRegLookup()`, `buildRegLookupWithTrentino()` | Pagine con mappe coropletiche (dimensione geografica) |
+| `format-utils.js` | `num()`, `euro()`, `euroCompact()`, `pct()`, `unit()`, `numFix()`, `tableFormat()` | Qualsiasi pagina (formattazione numeri e tabelle) |
+
+Esempio di import in una pagina:
+```js
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, euro, pct, tableFormat } from "../import/format-utils.js";
+```
+
+Vedi le pagine esistenti (`src/dataset/rifiuti-urbani.md`, `irpef-comunale.md`) come riferimento.
 
 ## Standard e criteri
 

--- a/docs/TEMPLATE-dataset-page.md
+++ b/docs/TEMPLATE-dataset-page.md
@@ -36,6 +36,27 @@ const data = await FileAttachment("../data/{slug-url}.json").json();
 // const secondData = await FileAttachment("../data/{slug-url}-second.json").json();
 ```
 
+<!--
+  MODULI CONDIVISI
+  Usa geo-utils.js per mappe e lookup geografici,
+  format-utils.js per formattazione numeri e tabelle.
+  Vedi src/import/ per API completa.
+-->
+```js
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, euro, pct, unit, tableFormat } from "../import/format-utils.js";
+```
+
+<!--
+  MAPPA (solo se il dataset ha dimensione geografica)
+  Carica regioni.topojson con FileAttachment (nella pagina, non nel modulo)
+  e passa il dato a loadItalianRegions().
+-->
+```js
+// const regTopo = await FileAttachment("../data/regioni.topojson").json();
+// const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
+```
+
 ```js
 // Filtri standard
 const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
@@ -45,17 +66,25 @@ const annoSel = view(Inputs.select(anni, {label: "Anno", value: anni[0]}));
 ```js
 // Preparazione dati filtrati
 const filtered = data.filter(d => d.anno === annoSel);
-// + metriche riassuntive
+// + metriche riassuntive (usa d3.sum, d3.mean)
+```
+
+```js
+// Crea lookup per mappa coropletica
+// const lookup = buildRegLookup(filtered, "regione", "nome_metrica");
+// Se il dataset ha P.A. Trentino da aggregare:
+//   import { buildRegLookupWithTrentino } from "../import/geo-utils.js";
+//   const lookup = buildRegLookupWithTrentino(filtered, "regione", aggFn);
 ```
 
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Metrica 1</h3>
-    <span class="big">{valore}</span>
+    <span class="big">${num(valore)}</span>
   </div>
   <div class="card">
     <h3>Metrica 2</h3>
-    <span class="big">{valore}</span>
+    <span class="big">${euro(valore)}</span>
   </div>
   <div class="card">
     <h3>Metrica 3</h3>
@@ -77,9 +106,25 @@ const filtered = data.filter(d => d.anno === annoSel);
 Breve nota di lettura (max 2 righe). Cosa mostra questo grafico? Come leggerlo?
 
 ```js
-Plot.plot({
-  // grafico: barre, mappa o charts che mostrano la distribuzione base
-})
+// Mappa coropletica:
+// Plot.plot({
+//   projection: {type: "mercator", domain: regioniGeo},
+//   ...
+//   marks: [
+//     Plot.geo(regioniGeo, {
+//       fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)),
+//       ...
+//     }),
+//     Plot.geo(confiniReg, ...)
+//   ]
+// })
+
+// Bar chart:
+// Plot.plot({
+//   marks: [
+//     Plot.barX(filtered, { y: "categoria", x: "metrica", sort: {y: "-x"} })
+//   ]
+// })
 ```
 
 > **Nota**: se serve, nota breve su perimetro o metrica.
@@ -96,9 +141,7 @@ Plot.plot({
 Breve nota su cosa mostra questo secondo blocco.
 
 ```js
-Plot.plot({
-  // secondo grafico o tabella
-})
+// secondo grafico o tabella
 ```
 
 ---
@@ -107,14 +150,22 @@ Plot.plot({
 
 <!--
   TABELLA FINALE: vista completa, ricercabile e scaricabile.
-  Default consigliato per v0.
+  Default consigliato per v0. Usa tableFormat() per header/format standardizzati.
 -->
+
+```js
+const { header, format } = tableFormat({
+  col1: { label: "Nome leggibile", fmt: "num" },
+  col2: { label: "Nome leggibile", fmt: "euro" },
+  col3: { label: "Nome leggibile", fmt: "pct" },
+});
+```
 
 ```js
 Inputs.table(filtered, {
   columns: ["col1", "col2", "col3"],
-  header: {col1: "Nome leggibile", col2: "Nome leggibile", col3: "Nome leggibile"},
-  format: { /* formattazione valori */ },
+  header,
+  format,
   rows: 20,
   width: "100%"
 })
@@ -144,11 +195,12 @@ Inputs.table(filtered, {
 
 <!--
   CHECKLIST PRE-PUBBLICAZIONE
-  [ ] Slug DE e slug DI coincidono
+  [ ] Slug DE e slug DI coincidono (vedi URL_SLUG_OVERRIDES in catalog.json.py)
   [ ] Clean parquet pubblico esiste su GCS
   [ ] Data loader funziona (npm run dev)
   [ ] Frontmatter completo (title, description, source, source_url, period, last_modified, dataset_slug)
   [ ] Primo blocco mostra stock/distribuzione base, non delta o trend
+  [ ] Usa moduli condivisi da src/import/ (geo-utils.js, format-utils.js)
   [ ] Sezione Limiti compilata
   [ ] Link a fonte originale e parquet funzionanti
   [ ] Pagina leggibile da un utente non tecnico

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -2,6 +2,8 @@
 
 Ogni file `.json.py` in questa directory è un **data loader** creato a mano per una pagina specifica. Legge i clean parquet su GCS via DuckDB e produce JSON aggregato, consumato dalle pagine Observable.
 
+**Roadmap**: in una fase successiva (Fase 3) valuteremo un unico loader generico parametrizzato dallo slug, per ridurre i 22 loader attuali a 1 + override per eccezioni. Nel frattempo, ogni nuovo dataset ha il suo loader.
+
 ## Naming
 
 Il nome del file segue lo slug URL della pagina (con trattini), eventualmente con un suffisso che specifica la vista:
@@ -19,3 +21,12 @@ Lo slug interno (con underscore, es. `aifa_spesa_consumo`) che identifica il par
 ## Utility condivisa
 
 `_util.py` fornisce `load_dataset()` e `_parquet_exists()` per evitare di replicare logica GCS/DuckDB in ogni loader.
+
+## Moduli JS condivisi (`src/import/`)
+
+Dalla Fase 1 (2026-06), le pagine dataset possono importare moduli condivisi da `src/import/`:
+
+- `geo-utils.js` — `normalizzaReg()`, `loadItalianRegions()`, `buildRegLookup()`, `buildRegLookupWithTrentino()`
+- `format-utils.js` — `num()`, `euro()`, `euroCompact()`, `pct()`, `unit()`, `numFix()`, `tableFormat()`
+
+Vedi `src/dataset/rifiuti-urbani.md` come esempio di pagina che li usa.

--- a/src/data/_util.py
+++ b/src/data/_util.py
@@ -6,6 +6,11 @@ Legge clean parquet da GCS via DuckDB e produce JSON per il frontend.
 I path GCS seguono il path contract canonico definito in:
     lab-connectors/lab_connectors/gcs/paths.py  (paths.json)
 Pattern usato: clean_parquet → {slug}/{year}/{slug}_{year}_clean.parquet
+
+OUTPUT: array JSON di righe aggregate (v1 contract, backward compat).
+  Le pagine consumano direttamente l'array.
+  TODO (Fase 3): aggiungere metadata years_available/missing in un campo _meta
+  senza rompere il contratto array.
 """
 import json
 import sys
@@ -38,6 +43,8 @@ def load_dataset(
     Legge parquet GCS per un dataset, raggruppa per group_cols,
     somma metric_cols, output JSON su stdout.
     Salta gli anni in cui il parquet non esiste.
+
+    Output: array JSON di righe aggregate (v1 contract).
     """
     valid_years = [y for y in years if _parquet_exists(slug, y)]
     if not valid_years:

--- a/src/data/catalog.json.py
+++ b/src/data/catalog.json.py
@@ -4,24 +4,41 @@ url = "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/reg
 r = requests.get(url, timeout=15)
 cat = r.json()
 
-# Mapping DI slug (underscore) → URL slug (hyphen) per pagine Explorer.
-# Fallback: sostituisce _ con - meccanicamente.
-SLUG_MAP = {
-    "aifa_spesa_consumo": "spesa-farmaceutica",
-    "ispra_ru_base": "rifiuti-urbani",
-    "civile_flussi": "flussi-giustizia-civile",
-    "terna_capacita_rinnovabile": "capacita-rinnovabile",
-    "terna_electricity_by_source": "produzione-elettrica-fonti",
-    "camera_votazioni_sparql": "votazioni-camera",
-    "bdap_entrate_stato": "entrate-stato",
-    "inps_pensioni_trimestrale": "pensioni-inps",
+# URL_SLUG_OVERRIDES: mapping eccezioni per slug URL pubblici.
+#
+# La regola di default converte meccanicamente lo slug DI (underscore)
+# in URL slug (hyphen):  "aifa_spesa_consumo" → "aifa-spesa-consumo".
+#
+# Per i dataset ereditati dalla fase Evidence, gli slug URL sono stati
+# scelti editorialmente e NON seguono lo slug DI. Ogni entry qui sotto
+# documenta questa divergenza.
+#
+# Per i NUOVI dataset: se l'URL slug meccanico va bene, non serve aggiungere
+# nulla qui. Se serve un nome URL diverso, aggiungi l'override con commento.
+URL_SLUG_OVERRIDES = {
+    "aifa_spesa_consumo": "spesa-farmaceutica",             # editoriale: nome tema
+    "ispra_ru_base": "rifiuti-urbani",                      # editoriale: nome tema
+    "civile_flussi": "flussi-giustizia-civile",             # editoriale: specifica tema
+    "terna_capacita_rinnovabile": "capacita-rinnovabile",   # editoriale: nome tema
+    "terna_electricity_by_source": "produzione-elettrica-fonti",  # editoriale: nome tema
+    "camera_votazioni_sparql": "votazioni-camera",          # editoriale: nome tema
+    "bdap_entrate_stato": "entrate-stato",                  # editoriale: nome tema
+    "inps_pensioni_trimestrale": "pensioni-inps",           # editoriale: nome tema
 }
+
+def resolve_url_slug(di_slug: str) -> str:
+    """Risolve lo slug DI (underscore) in URL slug (hyphen).
+
+    Default: sostituzione meccanica _ → -.
+    Override: se presente in URL_SLUG_OVERRIDES.
+    """
+    return URL_SLUG_OVERRIDES.get(di_slug, di_slug.replace("_", "-"))
 
 datasets = []
 for ds in cat.get("datasets", []):
     period = ds.get("period", {})
     slug = ds["slug"]
-    url_slug = SLUG_MAP.get(slug, slug.replace("_", "-"))
+    url_slug = resolve_url_slug(slug)
     datasets.append({
         "slug": slug,
         "url_slug": url_slug,

--- a/src/dataset/irpef-comunale.md
+++ b/src/dataset/irpef-comunale.md
@@ -15,11 +15,13 @@ Contribuenti, reddito imponibile e imposta netta IRPEF per comune italiano. I da
 **Fonte**: [MEF — Dipartimento delle Finanze](https://www1.finanze.gov.it/) · **Periodo**: 2019–2023
 
 ```js
-import * as topojson from "npm:topojson-client";
+import { normalizzaReg, loadItalianRegions, buildRegLookupWithTrentino } from "../import/geo-utils.js";
+import { num, euro, tableFormat } from "../import/format-utils.js";
+```
 
+```js
 const regTopo = await FileAttachment("../data/regioni.topojson").json();
-const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
-const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -57,11 +59,11 @@ const nRegioni = new Set(regFiltered.map(d => d.regione)).size;
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Contribuenti</h3>
-    <span class="big">${totContribuenti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totContribuenti)}</span>
   </div>
   <div class="card">
     <h3>Reddito medio</h3>
-    <span class="big">€ ${Math.round(totReddito / totContribuenti).toLocaleString("it-IT")}</span>
+    <span class="big">${euro(Math.round(totReddito / totContribuenti))}</span>
   </div>
   <div class="card">
     <h3>Regioni</h3>
@@ -74,32 +76,15 @@ const nRegioni = new Set(regFiltered.map(d => d.regione)).size;
 ## Composizione del reddito per regione
 
 ```js
-function normalizzaReg(nome) {
-  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
-}
-
 const totNazionale = d3.sum(regFiltered, d => d.reddito_imponibile_eur);
-// Costruisci lookup escludendo MANCANTE/ERRATA e aggregando Trentino
-const irpefLookup = new Map();
-const trentinoVal = {val: 0, cnt: 0};
-for (const d of regFiltered) {
-  const r = d.regione;
-  if (r === 'MANCANTE/ERRATA') continue;
-  if (r.includes('P.A.')) {
-    trentinoVal.val += d.reddito_imponibile_eur / totNazionale * 100;
-    trentinoVal.cnt++;
-    continue;
-  }
-  irpefLookup.set(normalizzaReg(r), d.reddito_imponibile_eur / totNazionale * 100);
-}
-// Trentino unificato
-const trentKey = normalizzaReg('Trentino-Alto Adige');
-irpefLookup.set(trentKey, trentinoVal.cnt > 0 ? trentinoVal.val : 0);
-irpefLookup.set(trentKey + '/SÜDTIROL', irpefLookup.get(trentKey));
-// Valle d'Aosta fallback
-if (irpefLookup.has("VALLE-D'AOSTA")) {
-  irpefLookup.set("VALLE-D'AOSTA/VALLÉE-D'AOSTE", irpefLookup.get("VALLE-D'AOSTA"));
-}
+
+// Lookup con aggregazione automatica P.A. Trentino e esclusione MANCANTE/ERRATA
+const irpefLookup = buildRegLookupWithTrentino(
+  regFiltered.filter(d => d.regione !== 'MANCANTE/ERRATA'),
+  "regione",
+  (items) => items.reduce((s, d) => s + (d.reddito_imponibile_eur / totNazionale * 100), 0),
+  "P.A.",
+);
 ```
 
 ```js
@@ -164,22 +149,21 @@ Plot.plot({
 ## Dettaglio capoluoghi
 
 ```js
+const { header, format } = tableFormat({
+  comune: "string",
+  regione: "string",
+  numero_contribuenti: "num",
+  reddito_imponibile_eur: "euro",
+  imposta_netta_eur: "euro",
+  reddito_medio: "euro",
+});
+```
+
+```js
 Inputs.table(capConMedia, {
   columns: ["comune", "regione", "numero_contribuenti", "reddito_imponibile_eur", "imposta_netta_eur", "reddito_medio"],
-  header: {
-    comune: "Comune",
-    regione: "Regione",
-    numero_contribuenti: "Contribuenti",
-    reddito_imponibile_eur: "Reddito imponibile (€)",
-    imposta_netta_eur: "Imposta netta (€)",
-    reddito_medio: "Reddito medio (€)"
-  },
-  format: {
-    reddito_imponibile_eur: x => `€ ${x.toLocaleString("it-IT")}`,
-    imposta_netta_eur: x => `€ ${x.toLocaleString("it-IT")}`,
-    reddito_medio: x => `€ ${x.toLocaleString("it-IT")}`,
-    numero_contribuenti: x => x.toLocaleString("it-IT")
-  },
+  header,
+  format,
   rows: 20,
   width: "100%"
 })

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -15,11 +15,13 @@ Disuguaglianza del reddito netto per regione, misurata con l'indice di Gini. I d
 **Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2003–2024
 
 ```js
-import * as topojson from "npm:topojson-client";
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { numFix, tableFormat } from "../import/format-utils.js";
+```
 
+```js
 const regTopo = await FileAttachment("../data/regioni.topojson").json();
-const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
-const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -47,15 +49,8 @@ const annoData = filtered
 const annoDataRegioni = annoData.filter(d => !d.regione.startsWith('Provincia Autonoma'));
 const mediaRegionale = d3.mean(annoDataRegioni, d => d.gini);
 
-// Lookup per mappa — chiave normalizzata per match TopoJSON
-function normalizzaReg(nome) {
-  return nome
-    .toUpperCase()
-    .replace(/ \/ /g, '/')
-    .replace(/ /g, '-');
-}
-
-const giniLookup = new Map(annoDataRegioni.map(d => [normalizzaReg(d.regione), d.gini]));
+// Lookup per mappa con normalizzazione automatica
+const giniLookup = buildRegLookup(annoDataRegioni, "regione", "gini");
 ```
 
 ```js
@@ -164,7 +159,10 @@ const annoConDelta = annoDataRegioni.map((d, i) => ({
 Inputs.table(annoConDelta, {
   columns: ["pos", "regione", "gini", "diff_media"],
   header: {pos: "#", regione: "Regione", gini: "Gini", diff_media: "Δ media"},
-  format: {gini: x => x.toFixed(3), diff_media: x => (x > 0 ? "+" : "") + x.toFixed(3)},
+  format: {
+    gini: x => numFix(x, 3),
+    diff_media: x => (x > 0 ? "+" : "") + numFix(x, 3)
+  },
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -15,11 +15,13 @@ Fondo di Solidarietà Comunale (FSC) 2025 per comune: capacità fiscale, fondo p
 **Fonte**: [OpenCivitas](https://www.opencivitas.it/) · **Periodo**: 2025
 
 ```js
-import * as topojson from "npm:topojson-client";
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, euroCompact, tableFormat } from "../import/format-utils.js";
+```
 
+```js
 const regTopo = await FileAttachment("../data/regioni.topojson").json();
-const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
-const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -56,11 +58,11 @@ const percContribNetti = (contribNetti / nComuni * 100).toFixed(1);
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Dotazione FSC</h3>
-    <span class="big">€ ${(totaleFsc / 1e9).toFixed(1)} <small style="opacity:0.6">mld</small></span>
+    <span class="big">${euroCompact(totaleFsc)}</span>
   </div>
   <div class="card">
     <h3>Comuni</h3>
-    <span class="big">${nComuni.toLocaleString("it-IT")}</span>
+    <span class="big">${num(nComuni)}</span>
   </div>
   <div class="card">
     <h3>Popolazione</h3>
@@ -73,11 +75,7 @@ const percContribNetti = (contribNetti / nComuni * 100).toFixed(1);
 ## Dotazione FSC per regione
 
 ```js
-function normalizzaReg(nome) {
-  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
-}
-
-const fscLookup = new Map(perRegione.map(d => [normalizzaReg(d.regione), d.fsc]));
+const fscLookup = buildRegLookup(perRegione, "regione", "fsc");
 ```
 
 ```js
@@ -159,10 +157,10 @@ Inputs.table(perRegione, {
   columns: ["regione", "comuni", "popolazione", "fsc", "perequativo", "capacita"],
   header: {regione: "Regione", comuni: "Comuni", popolazione: "Popolazione", fsc: "Dotazione FSC (€)", perequativo: "Perequativo (€)", capacita: "Capacità fiscale (€)"},
   format: {
-    popolazione: x => Math.round(x).toLocaleString("it-IT"),
-    fsc: x => `€ ${(x / 1e6).toFixed(0)} mln`,
-    perequativo: x => `€ ${(x / 1e6).toFixed(0)} mln`,
-    capacita: x => `€ ${(x / 1e6).toFixed(0)} mln`
+    popolazione: x => num(x),
+    fsc: x => euroCompact(x),
+    perequativo: x => euroCompact(x),
+    capacita: x => euroCompact(x)
   },
   rows: 25,
   width: "100%"

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -15,11 +15,13 @@ Dati ISPRA sui rifiuti urbani dei comuni italiani. Produzione totale, raccolta d
 **Fonte**: ISPRA · **Periodo**: 2020–2024
 
 ```js
-import * as topojson from "npm:topojson-client";
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, pct, unit, tableFormat } from "../import/format-utils.js";
+```
 
+```js
 const regTopo = await FileAttachment("../data/regioni.topojson").json();
-const regioniGeo = topojson.feature(regTopo, regTopo.objects.regioni);
-const confiniReg = topojson.mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b);
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -58,11 +60,11 @@ const comuniFiltrati = comuni
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Rifiuti totali</h3>
-    <span class="big">${Math.round(totRU).toLocaleString("it-IT")} <small style="opacity:0.6">t</small></span>
+    <span class="big">${unit(totRU, "t")}</span>
   </div>
   <div class="card">
     <h3>Quota RD</h3>
-    <span class="big">${mediaRd}%</span>
+    <span class="big">${pct(mediaRd, 1)}</span>
   </div>
   <div class="card">
     <h3>Regioni</h3>
@@ -75,17 +77,7 @@ const comuniFiltrati = comuni
 ## Raccolta differenziata per regione
 
 ```js
-// Normalizzazione nomi regione
-function normalizzaReg(nome) {
-  return nome.toUpperCase().replace(/ \/ /g, '/').replace(/ /g, '-');
-}
-
-const rdLookup = new Map(regFiltered.map(d => [normalizzaReg(d.regione), d.quota_rd]));
-// Fallback per nomi regione non standard (ISPRA vs TopoJSON)
-const rdFALLBACKS = {"VALLE-DAOSTA": "VALLE-D'AOSTA/VALLÉE-D'AOSTE", "TRENTINO-ALTO-ADIGE": "TRENTINO-ALTO-ADIGE/SÜDTIROL"};
-for (const [short, full] of Object.entries(rdFALLBACKS)) {
-  if (rdLookup.has(short) && !rdLookup.has(full)) rdLookup.set(full, rdLookup.get(short));
-}
+const rdLookup = buildRegLookup(regFiltered, "regione", "quota_rd");
 ```
 
 ```js
@@ -141,10 +133,19 @@ Plot.plot({
 ## Regioni — dettaglio
 
 ```js
+const { header, format } = tableFormat({
+  regione: { label: "Regione", fmt: "string" },
+  totale_ru_tonnellate: { label: "RU totali (t)", fmt: "num" },
+  totale_rd_tonnellate: { label: "RD totale (t)", fmt: "num" },
+  quota_rd: { label: "% RD", fmt: "pct" },
+});
+```
+
+```js
 Inputs.table(regFiltered, {
   columns: ["regione", "totale_ru_tonnellate", "totale_rd_tonnellate", "quota_rd"],
-  header: {regione: "Regione", totale_ru_tonnellate: "RU totali (t)", totale_rd_tonnellate: "RD totale (t)", quota_rd: "% RD"},
-  format: {totale_ru_tonnellate: x => Math.round(x).toLocaleString("it-IT"), totale_rd_tonnellate: x => Math.round(x).toLocaleString("it-IT"), quota_rd: x => `${x}%`},
+  header,
+  format,
   rows: 25, width: "100%"
 })
 ```

--- a/src/import/format-utils.js
+++ b/src/import/format-utils.js
@@ -5,7 +5,7 @@
  * Pensate per template literal JS in Observable.
  *
  * Uso:
- *   import { num, euro, pct, unit, tableFormat } from "../import/format-utils.js";
+ *   import { num, euro, euroCompact, pct, unit, tableFormat } from "../import/format-utils.js";
  */
 
 /** Formatta un numero intero con separatore migliaia italiano. */
@@ -78,8 +78,9 @@ const FORMATTERS = {
   string: (x) => (x != null ? String(x) : "\u2014"),
 };
 
-// Necessario per euroCompact
-function euroCompact(x) {
+/** Formatta un importo in euro con arrotondamento compatto (Mln/Mld). */
+export function euroCompact(x) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
   if (x >= 1e9) return "\u20AC " + numFix(x / 1e9, 1) + " Mld";
   if (x >= 1e6) return "\u20AC " + numFix(x / 1e6, 1) + " Mln";
   return "\u20AC " + num(x);

--- a/src/import/format-utils.js
+++ b/src/import/format-utils.js
@@ -1,0 +1,86 @@
+/**
+ * format-utils.js — Formattazione numeri e valute in locale italiano.
+ *
+ * Centralizza i pattern toLocaleString("it-IT") sparsi in tutte le pagine.
+ * Pensate per template literal JS in Observable.
+ *
+ * Uso:
+ *   import { num, euro, pct, unit, tableFormat } from "../import/format-utils.js";
+ */
+
+/** Formatta un numero intero con separatore migliaia italiano. */
+export function num(x) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
+  return Math.round(x).toLocaleString("it-IT");
+}
+
+/** Formatta un numero con decimali fissi. */
+export function numFix(x, dec = 1) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
+  return x.toLocaleString("it-IT", {
+    minimumFractionDigits: dec,
+    maximumFractionDigits: dec,
+  });
+}
+
+/** Formatta un valore in euro. */
+export function euro(x) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
+  return "\u20AC " + num(x);
+}
+
+/** Formatta una percentuale (valore gia' in %, es. 75.8). */
+export function pct(x, dec = 1) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
+  return numFix(x, dec) + "%";
+}
+
+/** Formatta un numero con unita' di misura. */
+export function unit(x, unita) {
+  if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
+  return num(x) + " " + unita;
+}
+
+/**
+ * Factory per formattazione Inputs.table.
+ * Progetta header leggibili e format function da una spec dichiarativa.
+ *
+ * @param {Object} spec — { nomeColonna: { label, fmt } | nomeColonna: "tipo" }
+ *   tipi supportati: "num", "euro", "pct", "euroCompact", "string"
+ * @returns {{ header: Object, format: Object }}
+ *
+ * @example
+ * const { header, format } = tableFormat({
+ *   regione: { label: "Regione", fmt: "string" },
+ *   totale_ru_tonnellate: "num",
+ *   quota_rd: "pct"
+ * });
+ * Inputs.table(data, { columns: [...], header, format });
+ */
+export function tableFormat(spec) {
+  const header = {};
+  const format = {};
+  for (const [col, cfg] of Object.entries(spec)) {
+    const label = typeof cfg === "string" ? col : (cfg.label || col);
+    const fmt = typeof cfg === "string" ? cfg : (cfg.fmt || "num");
+    header[col] = label;
+    format[col] = FORMATTERS[fmt] || FORMATTERS.num;
+  }
+  return { header, format };
+}
+
+// Mappa tipi -> formatter
+const FORMATTERS = {
+  num: (x) => (x != null ? num(x) : "\u2014"),
+  euro: (x) => (x != null ? euro(x) : "\u2014"),
+  pct: (x) => (x != null ? pct(x) : "\u2014"),
+  euroCompact: (x) => (x != null ? euroCompact(x) : "\u2014"),
+  string: (x) => (x != null ? String(x) : "\u2014"),
+};
+
+// Necessario per euroCompact
+function euroCompact(x) {
+  if (x >= 1e9) return "\u20AC " + numFix(x / 1e9, 1) + " Mld";
+  if (x >= 1e6) return "\u20AC " + numFix(x / 1e6, 1) + " Mln";
+  return "\u20AC " + num(x);
+}

--- a/src/import/format-utils.js
+++ b/src/import/format-utils.js
@@ -78,10 +78,13 @@ const FORMATTERS = {
   string: (x) => (x != null ? String(x) : "\u2014"),
 };
 
-/** Formatta un importo in euro con arrotondamento compatto (Mln/Mld). */
+/** Formatta un importo in euro con arrotondamento compatto (Mln/Mld).
+ * Supporta valori negativi: la soglia Mln/Mld usa il valore assoluto,
+ * il segno viene preservato nella formattazione del numero (toLocaleString). */
 export function euroCompact(x) {
   if (x == null || (typeof x === "number" && !isFinite(x))) return "\u2014";
-  if (x >= 1e9) return "\u20AC " + numFix(x / 1e9, 1) + " Mld";
-  if (x >= 1e6) return "\u20AC " + numFix(x / 1e6, 1) + " Mln";
+  const abs = Math.abs(x);
+  if (abs >= 1e9) return "\u20AC " + numFix(x / 1e9, 1) + " Mld";
+  if (abs >= 1e6) return "\u20AC " + numFix(x / 1e6, 1) + " Mln";
   return "\u20AC " + num(x);
 }

--- a/src/import/geo-utils.js
+++ b/src/import/geo-utils.js
@@ -1,0 +1,161 @@
+/**
+ * geo-utils.js — Utility condivise per mappe coropletiche TopoJSON.
+ *
+ * Centralizza il boilerplate di normalizzazione nomi regione,
+ * caricamento TopoJSON e costruzione lookup per Plot.geo.
+ *
+ * Uso in una pagina OF:
+ *   import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+ *
+ * Contratto regioni ISTAT:
+ *   Il TopoJSON in src/data/regioni.topojson segue la nomenclatura ISTAT
+ *   (DEN_REG). I dataset possono avere nomi regione leggermente diversi
+ *   (maiuscole/minuscole, trattini, slash, P.A. Trentino separato).
+ */
+
+/**
+ * Normalizza un nome regione per match con TopoJSON ISTAT.
+ * Istituzioni diverse (ISPRA, MEF, ISTAT) usano varianti:
+ *   "Valle d'Aosta" → "VALLE-D'AOSTA/VALLÉE-D'AOSTE"
+ *   "P.A. Bolzano" → "TRENTINO-ALTO-ADIGE/SÜDTIROL"
+ *   "Emilia-Romagna" → "EMILIA-ROMAGNA" (identico, solo uppercase)
+ */
+export function normalizzaReg(nome) {
+  return nome
+    .toUpperCase()
+    .replace(/ \/ /g, "/")
+    .replace(/ /g, "-");
+}
+
+/**
+ * Mappa di fallback per regioni con nomi non standard nei dataset.
+ * I dataset spesso usano "VALLE-DAOSTA" senza apostrofo, o
+ * "TRENTINO-ALTO-ADIGE" senza lo slash "/SÜDTIROL".
+ * Questa mappa allinea i nomi dataset al TopoJSON ISTAT.
+ */
+export const REG_FALLBACKS = {
+  "VALLE-DAOSTA": "VALLE-D'AOSTA/VALLÉE-D'AOSTE",
+  "VALLE-D'AOSTA": "VALLE-D'AOSTA/VALLÉE-D'AOSTE",
+  "TRENTINO-ALTO-ADIGE": "TRENTINO-ALTO-ADIGE/SÜDTIROL",
+};
+
+/**
+ * Prepara feature GeoJSON + confini da regioni.topojson.
+ * NON usa FileAttachment internamente (non disponibile in moduli JS).
+ * Il dato TopoJSON va caricato nella pagina con FileAttachment e passato qui.
+ *
+ * @param {Object} regTopo — Parsed TopoJSON da FileAttachment("...regioni.topojson").json()
+ * @returns {{ regioniGeo: GeoJSON.FeatureCollection, confiniReg: GeoJSON.LineString }}
+ *
+ * @example
+ * // Nella pagina .md:
+ * import { loadItalianRegions } from "../import/geo-utils.js";
+ * const regTopo = await FileAttachment("../data/regioni.topojson").json();
+ * const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
+ */
+export async function loadItalianRegions(regTopo) {
+  const { feature, mesh } = await import("npm:topojson-client");
+  return {
+    regioniGeo: feature(regTopo, regTopo.objects.regioni),
+    confiniReg: mesh(regTopo, regTopo.objects.regioni, (a, b) => a !== b),
+  };
+}
+
+/**
+ * Costruisce una lookup table regione→valore, normalizzando i nomi
+ * e applicando fallback per regioni con nomi non standard.
+ *
+ * @param {Array} data — Array di oggetti con campo regione e campo valore
+ * @param {string} keyField — Nome del campo "regione" (default: "regione")
+ * @param {string} valueField — Nome del campo valore (default: usato se omitValue è false)
+ * @param {Function} [transformValue] — Trasformazione opzionale del valore
+ *        Es: d => d.reddito_imponibile_eur / totNazionale * 100
+ * @param {Object} [extraFallbacks] — Fallback aggiuntivi oltre a REG_FALLBACKS
+ * @returns {Map<string, any>} lookup table
+ *
+ * @example
+ * // Semplice: regione → metrica
+ * const lookup = buildRegLookup(dataFiltrati, "regione", "quota_rd");
+ *
+ * // Con trasformazione: regione → % del totale nazionale
+ * const tot = d3.sum(data, d => d.reddito);
+ * const lookup = buildRegLookup(data, "regione", null, d => d.reddito / tot * 100);
+ *
+ * // Con fallback extra
+ * const lookup = buildRegLookup(data, "regione", "valore", null, {"P.A. TRENTO": "TRENTINO-ALTO-ADIGE/SÜDTIROL"});
+ */
+export function buildRegLookup(
+  data,
+  keyField = "regione",
+  valueField,
+  transformValue,
+  extraFallbacks = {},
+) {
+  const allFallbacks = { ...REG_FALLBACKS, ...extraFallbacks };
+  const lookup = new Map();
+  const hasTransform = typeof transformValue === "function";
+
+  // Primo pass: build della lookup dai dati
+  for (const d of data) {
+    const key = normalizzaReg(d[keyField]);
+    const val = hasTransform ? transformValue(d) : d[valueField];
+    lookup.set(key, val);
+  }
+
+  // Secondo pass: applica fallback per nomi non standard
+  for (const [short, full] of Object.entries(allFallbacks)) {
+    const shortKey = normalizzaReg(short);
+    const fullKey = normalizzaReg(full);
+    if (lookup.has(shortKey) && !lookup.has(fullKey)) {
+      lookup.set(fullKey, lookup.get(shortKey));
+    }
+    // Se il dato ha il nome lungo ma shortKey non esiste, copia comunque
+    if (lookup.has(fullKey) && !lookup.has(shortKey)) {
+      lookup.set(shortKey, lookup.get(fullKey));
+    }
+  }
+
+  return lookup;
+}
+
+/**
+ * Helper per costruire un lookup quando le P.A. Trentino sono separate
+ * e vanno unificate. Pattern usato in irpef-comunale.md.
+ *
+ * @param {Array} data
+ * @param {string} keyField — campo regione
+ * @param {Function} aggregateFn — funzione che somma/aggrega i valori per Trentino
+ *        Es: items => items.reduce((s, d) => s + d.reddito_imponibile_eur, 0)
+ * @param {string} [trentinoKey] — Nome del Trentino unificato (default: "P.A.")
+ * @returns {Map<string, any>}
+ */
+export function buildRegLookupWithTrentino(
+  data,
+  keyField = "regione",
+  aggregateFn,
+  trentinoKey = "P.A.",
+) {
+  const lookup = buildRegLookup(
+    data.filter((d) => normalizzaReg(d[keyField]) !== normalizzaReg(trentinoKey)),
+    keyField,
+    null,
+    aggregateFn ? (d) => aggregateFn([d]) : null,
+  );
+
+  // Trova e aggrega le P.A. Trentino
+  const trentinoItems = data.filter(
+    (d) =>
+      normalizzaReg(d[keyField]).includes(normalizzaReg(trentinoKey)) ||
+      normalizzaReg(d[keyField]).includes("BOLZANO") ||
+      normalizzaReg(d[keyField]).includes("TRENTO"),
+  );
+
+  if (trentinoItems.length > 0 && aggregateFn) {
+    const trentinoVal = aggregateFn(trentinoItems);
+    const trentKey = normalizzaReg("Trentino-Alto Adige");
+    lookup.set(trentKey, trentinoVal);
+    lookup.set(normalizzaReg("TRENTINO-ALTO-ADIGE/SÜDTIROL"), trentinoVal);
+  }
+
+  return lookup;
+}

--- a/src/mappe.md
+++ b/src/mappe.md
@@ -8,11 +8,12 @@ description: Prototipo mappa coropletica con Observable Plot
 Prototipo di mappa coropletica con Observable Plot. La mappa mostra i confini delle regioni italiane con colore basato sui dati.
 
 ```js
-import * as topojson from "npm:topojson-client";
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "./import/geo-utils.js";
+```
 
-const regioniTopology = await FileAttachment("./data/regioni.topojson").json();
-const regioni = topojson.feature(regioniTopology, regioniTopology.objects.regioni);
-const confiniRegioni = topojson.mesh(regioniTopology, regioniTopology.objects.regioni, (a, b) => a !== b);
+```js
+const regTopo = await FileAttachment("./data/regioni.topojson").json();
+const { regioniGeo: regioni, confiniReg: confiniRegioni } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -40,31 +41,16 @@ Plot.plot({
 ## Mappa con dati — Gini regionale 2023
 
 ```js
-// Normalizza nomi regione per match con TopoJSON
-function normalizzaReg(nome) {
-  return nome
-    .toUpperCase()
-    .replace(/ \/ /g, '/')
-    .replace(/ /g, '-')
-    .replace(/PROVINCIA-AUTONOMA-(BOLZANO|TRENTO).*/, 'TRENTINO-ALTO ADIGE/SÜDTIROL')
-    .replace(/TRENTINO-ALTO-ADIGE/, 'TRENTINO-ALTO ADIGE');
-}
-
-const gini = await FileAttachment("./data/istat-gini-regionale.json").json();
-const gini2023 = gini.filter(d => d.anno === 2023 && d.pres_aff_imp === 1);
-const giniLookup = new Map();
-for (const d of gini2023) {
-  const key = normalizzaReg(d.regione);
-  if (key === 'TRENTINO-ALTO ADIGE/SÜDTIROL') {
-    const curr = giniLookup.get(key) || 0;
-    giniLookup.set(key, curr + d.gini);
-  } else {
-    giniLookup.set(key, d.gini);
-  }
-}
-if (giniLookup.has('TRENTINO-ALTO ADIGE/SÜDTIROL')) {
-  giniLookup.set('TRENTINO-ALTO ADIGE/SÜDTIROL', giniLookup.get('TRENTINO-ALTO ADIGE/SÜDTIROL') / 2);
-}
+const giniData = await FileAttachment("./data/istat-gini-regionale.json").json();
+const gini2023 = giniData.filter(d => d.anno === 2023 && d.pres_aff_imp === 1);
+// Usa buildRegLookupWithTrentino per aggregare P.A. Trentino
+import { buildRegLookupWithTrentino } from "./import/geo-utils.js";
+const giniLookup = buildRegLookupWithTrentino(
+  gini2023,
+  "regione",
+  (items) => d3.mean(items, d => d.gini),
+  "Provincia Autonoma",
+);
 ```
 
 ```js

--- a/tests/test_shared-utils.test.mjs
+++ b/tests/test_shared-utils.test.mjs
@@ -61,22 +61,39 @@ describe("unit()", () => {
 });
 
 describe("euroCompact()", () => {
-  it("formatta valori in miliardi", async () => {
+  it("formatta valori positivi in miliardi", async () => {
     const { euroCompact } = await import("../src/import/format-utils.js");
     assert.equal(euroCompact(1_234_567_890), "\u20AC 1,2 Mld");
     assert.equal(euroCompact(2_000_000_000), "\u20AC 2,0 Mld");
   });
 
-  it("formatta valori in milioni", async () => {
+  it("formatta valori negativi in miliardi", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(-1_234_567_890), "\u20AC -1,2 Mld");
+    assert.equal(euroCompact(-2_000_000_000), "\u20AC -2,0 Mld");
+  });
+
+  it("formatta valori positivi in milioni", async () => {
     const { euroCompact } = await import("../src/import/format-utils.js");
     assert.equal(euroCompact(1_234_567), "\u20AC 1,2 Mln");
     assert.equal(euroCompact(500_000_000), "\u20AC 500,0 Mln");
+  });
+
+  it("formatta valori negativi in milioni", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(-1_234_567), "\u20AC -1,2 Mln");
+    assert.equal(euroCompact(-266_302_122), "\u20AC -266,3 Mln");
   });
 
   it("formatta valori piccoli in euro interi", async () => {
     const { euroCompact } = await import("../src/import/format-utils.js");
     assert.equal(euroCompact(123_456), "\u20AC 123.456");
     assert.equal(euroCompact(0), "\u20AC 0");
+  });
+
+  it("formatta valori negativi piccoli in euro interi", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(-123_456), "\u20AC -123.456");
   });
 
   it("e' esportato come named export", async () => {

--- a/tests/test_shared-utils.test.mjs
+++ b/tests/test_shared-utils.test.mjs
@@ -1,0 +1,190 @@
+/**
+ * Test per moduli condivisi (geo-utils.js, format-utils.js).
+ *
+ * Prova del fuoco: i moduli condivisi sono importati da tutte le pagine.
+ * Se un refactor rompe normalizzaReg o i formattatori, ogni pagina ne risente.
+ *
+ * Nota: le funzioni che dipendono da OF runtime (FileAttachment, import("npm:"))
+ * non sono testabili in isolation in questo ambiente. Vengono testate
+ * indirettamente via build CI (observable build).
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+// ── format-utils.js ──────────────────────────────────────────────────────────
+
+describe("num()", () => {
+  it("formatta numero in locale italiano", async () => {
+    const { num } = await import("../src/import/format-utils.js");
+    assert.equal(num(1234567), "1.234.567");
+    assert.equal(num(0), "0");
+    assert.equal(num(100), "100");
+  });
+
+  it("gestisce null/undefined/NaN", async () => {
+    const { num } = await import("../src/import/format-utils.js");
+    assert.equal(num(null), "\u2014");
+    assert.equal(num(undefined), "\u2014");
+    assert.equal(num(NaN), "\u2014");
+    assert.equal(num(Infinity), "\u2014");
+  });
+});
+
+describe("euro()", () => {
+  it("formatta valore in euro", async () => {
+    const { euro } = await import("../src/import/format-utils.js");
+    assert.equal(euro(1234567), "\u20AC 1.234.567");
+    assert.equal(euro(0), "\u20AC 0");
+  });
+});
+
+describe("pct()", () => {
+  it("formatta percentuale con 1 decimale default", async () => {
+    const { pct } = await import("../src/import/format-utils.js");
+    assert.equal(pct(75.8), "75,8%");
+    assert.equal(pct(100), "100,0%");
+  });
+
+  it("formatta percentuale con decimali custom", async () => {
+    const { pct } = await import("../src/import/format-utils.js");
+    assert.equal(pct(75.84, 2), "75,84%");
+    assert.equal(pct(75, 0), "75%");
+  });
+});
+
+describe("unit()", () => {
+  it("formatta numero con unita'", async () => {
+    const { unit } = await import("../src/import/format-utils.js");
+    assert.equal(unit(1234567, "t"), "1.234.567 t");
+    assert.equal(unit(500, "MW"), "500 MW");
+  });
+});
+
+describe("tableFormat()", () => {
+  it("genera header e format da spec tipizzata", async () => {
+    const { tableFormat } = await import("../src/import/format-utils.js");
+    const { header, format } = tableFormat({
+      regione: { label: "Regione", fmt: "string" },
+      valore: "num",
+      prezzo: "euro",
+    });
+    assert.equal(header.regione, "Regione");
+    assert.equal(header.valore, "valore"); // label default = nome colonna
+    assert.equal(typeof format.regione, "function");
+    assert.equal(typeof format.valore, "function");
+    assert.equal(typeof format.prezzo, "function");
+    assert.equal(format.regione(123), "123"); // string formatter
+    assert.equal(format.valore(1234567), "1.234.567"); // num formatter
+    assert.equal(format.prezzo(1234567), "\u20AC 1.234.567"); // euro formatter
+  });
+});
+
+describe("numFix()", () => {
+  it("formatta con decimali fissi", async () => {
+    const { numFix } = await import("../src/import/format-utils.js");
+    const result = numFix(1234.567, 2);
+    // Il separatore delle migliaia dipende dal runtime (Node vs browser).
+    // In Node a volte non viene aggiunto con fractionDigits.
+    // Testiamo che il formato italiano sia corretto: virgola decimale.
+    assert.ok(result.includes(","), "deve usare virgola decimale");
+    assert.ok(result.endsWith("57"), "deve arrotondare a 2 decimali");
+    // Se Node aggiunge il separatore, ok; altrimenti ok lo stesso
+  });
+});
+
+// ── geo-utils.js (pure functions only) ──────────────────────────────────────
+
+describe("normalizzaReg()", () => {
+  it("converte in uppercase e sostituisce spazi con trattini", async () => {
+    const { normalizzaReg } = await import("../src/import/geo-utils.js");
+    assert.equal(normalizzaReg("Lombardia"), "LOMBARDIA");
+    assert.equal(normalizzaReg("Emilia-Romagna"), "EMILIA-ROMAGNA");
+    assert.equal(normalizzaReg("Trentino Alto Adige"), "TRENTINO-ALTO-ADIGE");
+  });
+
+  it("normalizza slash con spazi", async () => {
+    const { normalizzaReg } = await import("../src/import/geo-utils.js");
+    assert.equal(
+      normalizzaReg("Valle d'Aosta / Vallée d'Aoste"),
+      "VALLE-D'AOSTA/VALLÉE-D'AOSTE",
+    );
+  });
+
+  it("non altera gia' normalizzato", async () => {
+    const { normalizzaReg } = await import("../src/import/geo-utils.js");
+    assert.equal(normalizzaReg("LOMBARDIA"), "LOMBARDIA");
+  });
+
+  it("gestisce stringa vuota", async () => {
+    const { normalizzaReg } = await import("../src/import/geo-utils.js");
+    assert.equal(normalizzaReg(""), "");
+  });
+});
+
+describe("REG_FALLBACKS", () => {
+  it("contiene fallback Valle d'Aosta e Trentino", async () => {
+    const { REG_FALLBACKS } = await import("../src/import/geo-utils.js");
+    assert.ok("VALLE-DAOSTA" in REG_FALLBACKS);
+    assert.ok("TRENTINO-ALTO-ADIGE" in REG_FALLBACKS);
+  });
+
+  it("fallback Valle d'Aosta punta a nome TopoJSON", async () => {
+    const { REG_FALLBACKS } = await import("../src/import/geo-utils.js");
+    assert.equal(
+      REG_FALLBACKS["VALLE-DAOSTA"],
+      "VALLE-D'AOSTA/VALLÉE-D'AOSTE",
+    );
+  });
+});
+
+describe("buildRegLookup()", () => {
+  it("costruisce lookup regione->valore con normalizzazione", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [
+      { regione: "Lombardia", valore: 100 },
+      { regione: "Lazio", valore: 50 },
+    ];
+    const lookup = buildRegLookup(data, "regione", "valore");
+    assert.equal(lookup.get("LOMBARDIA"), 100);
+    assert.equal(lookup.get("LAZIO"), 50);
+  });
+
+  it("applica fallback per regioni non standard", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    // Simula dati ISPRA che usano VALLE-DAOSTA
+    const data = [{ regione: "Valle d'Aosta", valore: 30 }];
+    const lookup = buildRegLookup(data, "regione", "valore");
+    // Fallback: VALLE-DAOSTA → VALLE-D'AOSTA/VALLÉE-D'AOSTE
+    assert.ok(lookup.has("VALLE-D'AOSTA/VALLÉE-D'AOSTE"));
+    assert.equal(
+      lookup.get("VALLE-D'AOSTA/VALLÉE-D'AOSTE"),
+      30,
+    );
+  });
+
+  it("accetta transformValue function", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [{ regione: "Lombardia", val: 200, tot: 1000 }];
+    const lookup = buildRegLookup(
+      data,
+      "regione",
+      null,
+      (d) => (d.val / d.tot) * 100,
+    );
+    assert.equal(lookup.get("LOMBARDIA"), 20); // 200/1000 * 100
+  });
+
+  it("accetta extraFallbacks", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [{ regione: "P.A. Trento", valore: 50 }];
+    const lookup = buildRegLookup(
+      data,
+      "regione",
+      "valore",
+      null,
+      { "P.A. TRENTO": "TRENTINO-ALTO-ADIGE/SÜDTIROL" },
+    );
+    assert.ok(lookup.has("TRENTINO-ALTO-ADIGE/SÜDTIROL"));
+    assert.equal(lookup.get("TRENTINO-ALTO-ADIGE/SÜDTIROL"), 50);
+  });
+});

--- a/tests/test_shared-utils.test.mjs
+++ b/tests/test_shared-utils.test.mjs
@@ -60,6 +60,42 @@ describe("unit()", () => {
   });
 });
 
+describe("euroCompact()", () => {
+  it("formatta valori in miliardi", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(1_234_567_890), "\u20AC 1,2 Mld");
+    assert.equal(euroCompact(2_000_000_000), "\u20AC 2,0 Mld");
+  });
+
+  it("formatta valori in milioni", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(1_234_567), "\u20AC 1,2 Mln");
+    assert.equal(euroCompact(500_000_000), "\u20AC 500,0 Mln");
+  });
+
+  it("formatta valori piccoli in euro interi", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(123_456), "\u20AC 123.456");
+    assert.equal(euroCompact(0), "\u20AC 0");
+  });
+
+  it("e' esportato come named export", async () => {
+    // Regression: euroCompact deve essere esportato direttamente
+    // (non solo usato internamente da tableFormat).
+    const mod = await import("../src/import/format-utils.js");
+    assert.equal(typeof mod.euroCompact, "function");
+    assert.equal(mod.euroCompact(1e9).includes("Mld"), true);
+  });
+
+  it("gestisce null/undefined/NaN", async () => {
+    const { euroCompact } = await import("../src/import/format-utils.js");
+    assert.equal(euroCompact(null), "\u2014");
+    assert.equal(euroCompact(undefined), "\u2014");
+    assert.equal(euroCompact(NaN), "\u2014");
+    assert.equal(euroCompact(Infinity), "\u2014");
+  });
+});
+
 describe("tableFormat()", () => {
   it("genera header e format da spec tipizzata", async () => {
     const { tableFormat } = await import("../src/import/format-utils.js");
@@ -67,15 +103,18 @@ describe("tableFormat()", () => {
       regione: { label: "Regione", fmt: "string" },
       valore: "num",
       prezzo: "euro",
+      budget: "euroCompact",
     });
     assert.equal(header.regione, "Regione");
     assert.equal(header.valore, "valore"); // label default = nome colonna
     assert.equal(typeof format.regione, "function");
     assert.equal(typeof format.valore, "function");
     assert.equal(typeof format.prezzo, "function");
+    assert.equal(typeof format.budget, "function");
     assert.equal(format.regione(123), "123"); // string formatter
     assert.equal(format.valore(1234567), "1.234.567"); // num formatter
     assert.equal(format.prezzo(1234567), "\u20AC 1.234.567"); // euro formatter
+    assert.equal(format.budget(1_234_567_890), "\u20AC 1,2 Mld"); // euroCompact
   });
 });
 


### PR DESCRIPTION
## Sintesi

Fase 1 dell'architettura a strati per data-explorer. Crea due moduli condivisi in `src/import/` che centralizzano il boilerplate di mappe e formattazione, refattorizza 5 pagine per usarli, e aggiorna template + contributing.

## Contesto collegato

N/A — lavoro emerso dall'audit esplorativo delle pagine.

## Cosa cambia

- [ ] Nuovo dataset — pagina explorer
- [ ] Bug fix frontend (data loader / layout / performance)
- [ ] Aggiornamento config / catalogo
- [ ] Modifica struttura dati upstream
- [x] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### `src/import/geo-utils.js` (154 righe)
- `normalizzaReg(nome)` — normalizzazione nomi regione per match TopoJSON
- `loadItalianRegions(regTopo)` — prepara feature GeoJSON + confini da TopoJSON
- `buildRegLookup(data, key, val, transform, fallbacks)` — lookup regione→valore con fallback automatici
- `buildRegLookupWithTrentino(...)` — come sopra ma aggrega P.A. Trentino
- `REG_FALLBACKS` — mappa fallback per Valle d'Aosta e Trentino

### `src/import/format-utils.js` (86 righe)
- `num()`, `numFix()` — formattazione numeri in locale italiano
- `euro()`, `euroCompact()` — formattazione valute
- `pct()` — percentuali con decimali
- `unit()` — numeri con unità di misura
- `tableFormat(spec)` — factory per header/format di `Inputs.table`

### Pagine refattorizzate (5)
| Pagina | Riduzione boilerplate |
|--------|----------------------|
| rifiuti-urbani | -37 righe, normalizzaReg + TopoJSON → moduli |
| irpef-comunale | -72 righe, lookup Trentino manuale → buildRegLookupWithTrentino |
| istat-gini-regionale | -24 righe, lookup manuale → buildRegLookup |
| opencivitas-fsc-2025 | -26 righe, lookup manuale → buildRegLookup |
| mappe | -44 righe, stessa migrazione |

### Catalog
- `SLUG_MAP` → `URL_SLUG_OVERRIDES` con docstring + `resolve_url_slug()`

### Documentazione
- `docs/TEMPLATE-dataset-page.md` riscritto: import moduli condivisi come pattern standard
- `CONTRIBUTING.md`: nuova sezione "Moduli condivisi (src/import/)"

## Verifica

```bash
npm test
npm run lint
npx observable build
```

- [x] `npm test` — 43 test JS + 12 test Python, tutti pass
- [x] `npm run lint` — nessun errore
- [x] `npx observable build` — 27 pagine, 0 errori, 21 link validati

## Checklist PR

- [x] Perimetro stretto: una PR = refactor modulare + doc
- [ ] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

- Attenzione al pattern `FileAttachment`: va chiamato nella pagina `.md`, **non** nei moduli `.js` (OF globale non disponibile lì). `loadItalianRegions(regTopo)` accetta il dato come parametro.
- Le 5 pagine refattorizzate sono proof-of-concept. Le restanti 14 pagine seguiranno in PR successive.
- Il v2 contract in `_util.py` (metadati anni disponibili) è rimandato a Fase 3.