### PR TITLE
feat: refactor 13 pagine dataset con moduli condivisi (Fase 2)

### DIFF
--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -15,6 +15,10 @@ I costi sostenuti dalle regioni italiane per garantire i Livelli Essenziali di A
 **Fonte**: BDAP — Banca Dati delle Amministrazioni Pubbliche · **Periodo**: 2024
 
 ```js
+import { pct } from "../import/format-utils.js";
+```
+
+```js
 const regioni = await FileAttachment("../data/bdap-lea-regioni.json").json();
 const macro = await FileAttachment("../data/bdap-lea-macro.json").json();
 ```
@@ -75,7 +79,7 @@ Plot.plot({
     Plot.text(macroConPct, {
       y: "descrizione_voce_contabile",
       x: "importo_totale",
-      text: d => `${d.pct.toFixed(1)}%`,
+      text: d => pct(d.pct, 1),
       dx: 6,
       textAnchor: "start",
       fill: "var(--theme-foreground-muted)",

--- a/src/dataset/capacita-rinnovabile.md
+++ b/src/dataset/capacita-rinnovabile.md
@@ -15,6 +15,10 @@ Dati Terna sulla capacità di generazione rinnovabile installata per regione e f
 **Fonte**: Terna · **Periodo**: 2023–2024
 
 ```js
+import { num, unit } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/terna-fonti.json").json();
 ```
 
@@ -36,7 +40,7 @@ const nRegioni = new Set(filtered.map(d => d.regione)).size;
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Potenza totale</h3>
-    <span class="big">${Math.round(totNazionale).toLocaleString("it-IT")} <small style="opacity:0.6">MW</small></span>
+    <span class="big">${unit(totNazionale, "MW")}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>
@@ -112,7 +116,7 @@ Plot.plot({
 Inputs.table(filtered, {
   columns: ["regione", "fonti", "potenza_mw"],
   header: {regione: "Regione", fonti: "Fonte", potenza_mw: "Potenza (MW)"},
-  format: {potenza_mw: x => `${Math.round(x).toLocaleString("it-IT")} MW`},
+  format: {potenza_mw: x => unit(x, "MW")},
   rows: 30,
   width: "100%"
 })

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -15,6 +15,10 @@ La spesa della Pubblica Amministrazione per beni e servizi acquistati attraverso
 **Fonte**: Consip · **Periodo**: 2023–2025
 
 ```js
+import { num, euro, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const regioni = await FileAttachment("../data/consip-consumi-convenzione-regioni.json").json();
 const tipologie = await FileAttachment("../data/consip-consumi-convenzione-tipologie.json").json();
 ```
@@ -40,7 +44,7 @@ const totOrdini = regioni
   </div>
   <div class="card">
     <h3>Ordini</h3>
-    <span class="big">${totOrdini.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totOrdini)}</span>
   </div>
 </div>
 
@@ -118,17 +122,15 @@ Plot.plot({
 ## Dettaglio regioni
 
 ```js
+const { header, format } = tableFormat({
+  regione_pa: { label: "Regione PA", fmt: "string" },
+  valore_economico_consumi: { label: "Spesa (€)", fmt: "euro" },
+  numero_ordini_con_consumi: { label: "Ordini", fmt: "num" },
+});
 Inputs.table(regFiltered, {
   columns: ["regione_pa", "valore_economico_consumi", "numero_ordini_con_consumi"],
-  header: {
-    regione_pa: "Regione PA",
-    valore_economico_consumi: "Spesa (€)",
-    numero_ordini_con_consumi: "Ordini"
-  },
-  format: {
-    valore_economico_consumi: x => `€ ${Math.round(x).toLocaleString("it-IT")}`,
-    numero_ordini_con_consumi: x => x.toLocaleString("it-IT")
-  },
+  header,
+  format,
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/dipendenti-pubblici.md
+++ b/src/dataset/dipendenti-pubblici.md
@@ -15,6 +15,10 @@ Dati BDAP/RGS sui dipendenti pubblici italiani per comparto nel periodo 2010-202
 **Fonte**: MEF · RGS · BDAP · **Periodo**: 2010–2023
 
 ```js
+import { num, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/dipendenti-pubblici.json").json();
 ```
 
@@ -38,11 +42,11 @@ const pctDonne2023 = Math.round(data.filter(d => d.anno === 2023).reduce((s, d) 
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Dipendenti 2023</h3>
-    <span class="big">${tot2023.toLocaleString("it-IT")}</span>
+    <span class="big">${num(tot2023)}</span>
   </div>
   <div class="card">
     <h3>Variazione 2010→2023</h3>
-    <span class="big">${(delta > 0 ? "+" : "")}${delta.toLocaleString("it-IT")}</span>
+    <span class="big">${(delta > 0 ? "+" : "")}${num(delta)}</span>
   </div>
   <div class="card">
     <h3>Donne %</h3>
@@ -111,10 +115,17 @@ Plot.plot({
 ## Tabella per comparto
 
 ```js
+const { header, format } = tableFormat({
+  anno: { label: "Anno", fmt: "string" },
+  comparto: { label: "Comparto", fmt: "string" },
+  donne: { label: "Donne", fmt: "num" },
+  uomini: { label: "Uomini", fmt: "num" },
+  totale: { label: "Totale", fmt: "num" },
+});
 Inputs.table(filtered, {
   columns: ["anno", "comparto", "donne", "uomini", "totale"],
-  header: {comparto: "Comparto", donne: "Donne", uomini: "Uomini", totale: "Totale"},
-  format: {anno: x => String(x), donne: x => x.toLocaleString("it-IT"), uomini: x => x.toLocaleString("it-IT"), totale: x => x.toLocaleString("it-IT")},
+  header,
+  format,
   rows: 20,
   width: "100%"
 })

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -15,6 +15,10 @@ Dati del Ministero della Giustizia sui flussi civili nei tribunali distrettuali 
 **Fonte**: Ministero della Giustizia · **Periodo**: 2014–2025
 
 ```js
+import { num, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/civile-flussi.json").json();
 ```
 
@@ -42,15 +46,15 @@ const totPendenti = filtered.reduce((s, d) => s + d.pendenti_finali, 0);
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Sopravvenuti</h3>
-    <span class="big">${totSopravvenuti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totSopravvenuti)}</span>
   </div>
   <div class="card">
     <h3>Definiti</h3>
-    <span class="big">${totDefiniti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totDefiniti)}</span>
   </div>
   <div class="card">
     <h3>Pendenti finali</h3>
-    <span class="big">${totPendenti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totPendenti)}</span>
   </div>
 </div>
 
@@ -84,7 +88,7 @@ Plot.plot({
       x: "anno_str",
       y: "distretto",
       fill: "pendenti_finali",
-      tip: {format: {fill: d => d.toLocaleString("it-IT")}}
+      tip: {format: {fill: d => num(d)}}
     }),
     Plot.text(heatmapData, {
       x: "anno_str",
@@ -135,10 +139,17 @@ Plot.plot({
 ## Dettaglio per distretto
 
 ```js
+const { header, format } = tableFormat({
+  distretto: { label: "Distretto", fmt: "string" },
+  sopravvenuti: { label: "Sopravvenuti", fmt: "num" },
+  definiti_totale: { label: "Definiti", fmt: "num" },
+  pendenti_finali: { label: "Pendenti", fmt: "num" },
+  rapporto_def_sop: { label: "Rapporto D/S", fmt: "string" },
+});
 Inputs.table(filtered, {
   columns: ["distretto", "sopravvenuti", "definiti_totale", "pendenti_finali", "rapporto_def_sop"],
-  header: {distretto: "Distretto", sopravvenuti: "Sopravvenuti", definiti_totale: "Definiti", pendenti_finali: "Pendenti", rapporto_def_sop: "Rapporto D/S"},
-  format: {sopravvenuti: x => x.toLocaleString("it-IT"), definiti_totale: x => x.toLocaleString("it-IT"), pendenti_finali: x => x.toLocaleString("it-IT")},
+  header,
+  format,
   rows: 30,
   width: "100%"
 })

--- a/src/dataset/housing-crowding.md
+++ b/src/dataset/housing-crowding.md
@@ -15,6 +15,10 @@ Indice di densità abitativa (componenti per 100 mq) per titolo di godimento. I 
 **Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2004–2025
 
 ```js
+import { numFix } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/housing-crowding.json").json();
 ```
 
@@ -31,7 +35,7 @@ const totale = d3.mean(filtered, d => d.componenti_per_100mq);
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Densità media</h3>
-    <span class="big">${totale.toFixed(1)}</span>
+    <span class="big">${numFix(totale, 1)}</span>
     <small style="opacity:0.6">componenti/100mq</small>
   </div>
   <div class="card">
@@ -40,7 +44,7 @@ const totale = d3.mean(filtered, d => d.componenti_per_100mq);
   </div>
   <div class="card">
     <h3>Min – Max</h3>
-    <span class="big">${d3.min(filtered, d => d.componenti_per_100mq).toFixed(1)} – ${d3.max(filtered, d => d.componenti_per_100mq).toFixed(1)}</span>
+    <span class="big">${numFix(d3.min(filtered, d => d.componenti_per_100mq), 1)} – ${numFix(d3.max(filtered, d => d.componenti_per_100mq), 1)}</span>
   </div>
 </div>
 
@@ -117,7 +121,7 @@ Plot.plot({
 Inputs.table(trend, {
   columns: ["anno", "titolo_godimento", "componenti_per_100mq"],
   header: {anno: "Anno", titolo_godimento: "Titolo godimento", componenti_per_100mq: "Comp./100mq"},
-  format: {componenti_per_100mq: x => x.toFixed(2)},
+  format: {componenti_per_100mq: x => numFix(x, 2)},
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/istat-ipab-aree.md
+++ b/src/dataset/istat-ipab-aree.md
@@ -15,6 +15,10 @@ L'indice dei prezzi delle abitazioni (IPAB) misura l'evoluzione dei prezzi delle
 **Fonte**: ISTAT · **Periodo**: 2010–2025 · Dati trimestrali
 
 ```js
+import { numFix } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/istat-ipab-aree.json").json();
 ```
 
@@ -104,7 +108,7 @@ Plot.plot({
 Inputs.table(ultimiValori, {
   columns: ["area", "indice_prezzi"],
   header: {area: "Area", indice_prezzi: "Indice prezzi"},
-  format: {indice_prezzi: x => x.toFixed(1)},
+  format: {indice_prezzi: x => numFix(x, 1)},
   sort: "area",
   rows: 10,
   width: "100%"

--- a/src/dataset/mim-alunni-corso-eta.md
+++ b/src/dataset/mim-alunni-corso-eta.md
@@ -15,6 +15,10 @@ Alunni delle scuole statali italiane per ordine scolastico (primaria, secondaria
 **Fonte**: [MIM](https://dati.istruzione.it/opendata/) · **Periodo**: 2015–2025
 
 ```js
+import { num, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/mim-alunni-corso-eta.json").json();
 ```
 
@@ -146,14 +150,16 @@ const pivot = Array.from(
 ```
 
 ```js
+const { header, format } = tableFormat({
+  regione: { label: "Regione", fmt: "string" },
+  "SCUOLA PRIMARIA": { label: "Primaria", fmt: "num" },
+  "SCUOLA SECONDARIA I GRADO": { label: "Secondaria I", fmt: "num" },
+  "SCUOLA SECONDARIA II GRADO": { label: "Secondaria II", fmt: "num" },
+});
 Inputs.table(pivot, {
   columns: ["regione", "SCUOLA PRIMARIA", "SCUOLA SECONDARIA I GRADO", "SCUOLA SECONDARIA II GRADO"],
-  header: {regione: "Regione", "SCUOLA PRIMARIA": "Primaria", "SCUOLA SECONDARIA I GRADO": "Secondaria I", "SCUOLA SECONDARIA II GRADO": "Secondaria II"},
-  format: {
-    "SCUOLA PRIMARIA": x => (x || 0).toLocaleString("it-IT"),
-    "SCUOLA SECONDARIA I GRADO": x => (x || 0).toLocaleString("it-IT"),
-    "SCUOLA SECONDARIA II GRADO": x => (x || 0).toLocaleString("it-IT")
-  },
+  header,
+  format,
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/mit-incidentalita.md
+++ b/src/dataset/mit-incidentalita.md
@@ -15,6 +15,10 @@ Serie mensile di incidenti stradali, morti e feriti in Italia. I dati mostrano l
 **Fonte**: [MIT](https://www.mit.gov.it/) · **Periodo**: 2001–2018 · Dati mensili
 
 ```js
+import { num, numFix } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/mit-incidentalita.json").json();
 ```
 
@@ -45,16 +49,16 @@ const annuale = Array.from(
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Incidenti</h3>
-    <span class="big">${totIncidenti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totIncidenti)}</span>
     <small style="opacity:0.6">${String(annoSel)}</small>
   </div>
   <div class="card">
     <h3>Morti</h3>
-    <span class="big">${totMorti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totMorti)}</span>
   </div>
   <div class="card">
     <h3>Feriti</h3>
-    <span class="big">${totFeriti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totFeriti)}</span>
   </div>
 </div>
 
@@ -126,11 +130,11 @@ Inputs.table(filtered, {
   columns: ["mese", "incidenti", "morti", "feriti", "indice_mortalita", "indice_gravita"],
   header: {mese: "Mese", incidenti: "Incidenti", morti: "Morti", feriti: "Feriti", indice_mortalita: "Mort.%", indice_gravita: "Grav.%"},
   format: {
-    incidenti: x => x.toLocaleString("it-IT"),
-    morti: x => x.toLocaleString("it-IT"),
-    feriti: x => x.toLocaleString("it-IT"),
-    indice_mortalita: x => x.toFixed(2) + "%",
-    indice_gravita: x => x.toFixed(2) + "%"
+    incidenti: x => num(x),
+    morti: x => num(x),
+    feriti: x => num(x),
+    indice_mortalita: x => numFix(x, 2) + "%",
+    indice_gravita: x => numFix(x, 2) + "%"
   },
   rows: 15,
   width: "100%"

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -15,6 +15,10 @@ Popolazione residente italiana per fascia d'età, sesso e anno. I dati mostrano 
 **Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2019–2025
 
 ```js
+import { num, pct, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/popolazione-istat.json").json();
 ```
 
@@ -49,8 +53,8 @@ const trend = Array.from(
   </div>
   <div class="card">
     <h3>Femmine</h3>
-    <span class="big">${pctFemmine.toFixed(1)}%</span>
-    <small style="opacity:0.6">maschi ${(100 - pctFemmine).toFixed(1)}%</small>
+    <span class="big">${pct(pctFemmine, 1)}</span>
+    <small style="opacity:0.6">maschi ${pct(100 - pctFemmine, 1)}</small>
   </div>
   <div class="card">
     <h3>Fasce d'età</h3>
@@ -157,14 +161,16 @@ Plot.plot({
 ## Dettaglio per fascia
 
 ```js
+const { header, format } = tableFormat({
+  fascia_eta: { label: "Fascia d'età", fmt: "string" },
+  popolazione_residente: { label: "Totale", fmt: "num" },
+  totale_maschi: { label: "Maschi", fmt: "num" },
+  totale_femmine: { label: "Femmine", fmt: "num" },
+});
 Inputs.table(filtered, {
   columns: ["fascia_eta", "popolazione_residente", "totale_maschi", "totale_femmine"],
-  header: {fascia_eta: "Fascia d'età", popolazione_residente: "Totale", totale_maschi: "Maschi", totale_femmine: "Femmine"},
-  format: {
-    popolazione_residente: x => x.toLocaleString("it-IT"),
-    totale_maschi: x => x.toLocaleString("it-IT"),
-    totale_femmine: x => x.toLocaleString("it-IT")
-  },
+  header,
+  format,
   rows: 10,
   width: "100%"
 })

--- a/src/dataset/produzione-elettrica-fonti.md
+++ b/src/dataset/produzione-elettrica-fonti.md
@@ -15,6 +15,10 @@ Produzione netta di energia elettrica in GWh per fonte e regione. I dati mostran
 **Fonte**: [Terna](https://www.terna.it/) · **Periodo**: 2023–2024
 
 ```js
+import { num, unit } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/produzione-elettrica-fonti.json").json();
 ```
 
@@ -48,7 +52,7 @@ const nRegioni = perRegione.length;
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Produzione totale</h3>
-    <span class="big">${Math.round(totaleGWh).toLocaleString("it-IT")} <small style="opacity:0.6">GWh</small></span>
+    <span class="big">${unit(totaleGWh, "GWh")}</span>
   </div>
   <div class="card">
     <h3>Fonti</h3>
@@ -138,7 +142,7 @@ Plot.plot({
 Inputs.table(filtered, {
   columns: ["regione", "fonte", "produzione_gwh"],
   header: {regione: "Regione", fonte: "Fonte", produzione_gwh: "Produzione (GWh)"},
-  format: {produzione_gwh: x => `${Math.round(x).toLocaleString("it-IT")} GWh`},
+  format: {produzione_gwh: x => unit(x, "GWh")},
   rows: 30,
   width: "100%"
 })

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -15,6 +15,10 @@ Spesa e consumo della farmaceutica convenzionata SSN, disaggregati per regione, 
 **Fonte**: AIFA · **Periodo**: 2018–2024
 
 ```js
+import { num, euro, tableFormat } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/aifa-spesa.json").json();
 ```
 
@@ -134,10 +138,15 @@ Plot.plot({
 ## Dettaglio regioni
 
 ```js
+const { header, format } = tableFormat({
+  regione: { label: "Regione", fmt: "string" },
+  spesa: { label: "Spesa (€)", fmt: "euro" },
+  confezioni: { label: "Confezioni", fmt: "num" },
+});
 Inputs.table(perRegione, {
   columns: ["regione", "spesa", "confezioni"],
-  header: {regione: "Regione", spesa: "Spesa (€)", confezioni: "Confezioni"},
-  format: {spesa: x => `€ ${Math.round(x).toLocaleString("it-IT")}`, confezioni: x => Math.round(x).toLocaleString("it-IT")},
+  header,
+  format,
   rows: 25,
   width: "100%"
 })

--- a/src/dataset/votazioni-camera.md
+++ b/src/dataset/votazioni-camera.md
@@ -15,6 +15,10 @@ Esito, conteggi e indicatori (favorevoli, contrari, astenuti, presenti, fiducia)
 **Fonte**: [Camera dei Deputati](https://dati.camera.it/) · **Periodo**: 2018–2025
 
 ```js
+import { num, pct } from "../import/format-utils.js";
+```
+
+```js
 const data = await FileAttachment("../data/votazioni-camera.json").json();
 
 // Estrai anno dalla data
@@ -41,12 +45,12 @@ const pctApprovati = totVoti > 0 ? Math.round(approvati / totVoti * 1000) / 10 :
 <div class="grid grid-cols-3">
   <div class="card">
     <h3>Votazioni</h3>
-    <span class="big">${totVoti.toLocaleString("it-IT")}</span>
+    <span class="big">${num(totVoti)}</span>
   </div>
   <div class="card">
     <h3>Approvati</h3>
-    <span class="big">${pctApprovati}%</span>
-    <small style="opacity:0.6">${approvati.toLocaleString("it-IT")} su ${totVoti.toLocaleString("it-IT")}</small>
+    <span class="big">${pct(pctApprovati, 1)}</span>
+    <small style="opacity:0.6">${num(approvati)} su ${num(totVoti)}</small>
   </div>
   <div class="card">
     <h3>Fiducia</h3>
@@ -86,7 +90,7 @@ Plot.plot({
       x: "anno",
       y: "tot",
       fill: "#4e79a7",
-      tip: {format: {y: d => d.toLocaleString("it-IT")}}
+      tip: {format: {y: d => num(d)}}
     }),
     Plot.barY(perAnno, {
       x: "anno",


### PR DESCRIPTION
## Sintesi

Refactor di 13 pagine dataset per usare i moduli condivisi introdotti nella PR #148 (`src/import/geo-utils.js`, `src/import/format-utils.js`). Sostituisce tutti i pattern `toLocaleString("it-IT")` e formattazione manuale con funzioni standardizzate.

## Contesto collegato

Completa la Fase 2 dell'architettura a strati iniziata con la PR #148.

## Cosa cambia

- [ ] Nuovo dataset — pagina explorer
- [ ] Bug fix frontend (data loader / layout / performance)
- [ ] Aggiornamento config / catalogo
- [ ] Modifica struttura dati upstream
- [ ] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### Pattern sostituiti

| Vecchio pattern | Nuovo pattern |
|---|---|
| `x.toLocaleString("it-IT")` | `num(x)` |
| `Math.round(x).toLocaleString("it-IT")` | `num(x)` |
| `\`€ \${Math.round(x).toLocaleString("it-IT")}\`` | `euro(x)` |
| `\`\${Math.round(x).toLocaleString("it-IT")} MW\`` | `unit(x, "MW")` |
| `x.toFixed(2) + "%"` | `numFix(x, 2) + "%"` |
| `Inputs.table({ header: {...}, format: {...} })` | `tableFormat(...)` + `{ header, format }` |

### Pagine refattorizzate (13)

| Pagina | Pattern principali |
|--------|-------------------|
| bdap-lea | pct |
| capacita-rinnovabile | num, unit (MW) |
| consip-consumi-convenzione | num, euro, tableFormat |
| dipendenti-pubblici | num, tableFormat |
| flussi-giustizia-civile | num, tableFormat |
| housing-crowding | numFix |
| istat-ipab-aree | numFix |
| mim-alunni-corso-eta | num, tableFormat |
| mit-incidentalita | num, numFix |
| popolazione-istat | num, pct, tableFormat |
| produzione-elettrica-fonti | num, unit (GWh) |
| spesa-farmaceutica | num, euro, tableFormat |
| votazioni-camera | num, pct |

### Pagine senza modifiche (2)
- **entrate-stato**, **pensioni-inps**: già prive di `toLocaleString` e formattazione manuale.

## Impatto

- **Zero `toLocaleString("it-IT")` rimasti** in tutte le 19 pagine dataset
- Tutte le 19 pagine ora importano da `src/import/`
- Il boilerplate di formattazione è centralizzato: cambiare il formato numerico italiano (es. separatore migliaia) si fa in un unico file

## Verifica

```bash
npm test        # 51 JS + 12 Python ✅
npm run lint    # OK ✅
npx observable build  # 27 pagine, 0 errori, 21 link ✅
```

## Checklist PR

- [x] Perimetro stretto: solo refactor meccanico, nessuna logica cambiata
