### PR TITLE
feat: sidebar auto-generata da themes.json + search home page (Fase 4+5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "data loader check bypassed — i loader sono manuali e tracciati in git"
 
       - name: Build Observable Framework
-        run: npx observable build
+        run: npm run build
 
       - name: Copy CNAME for custom domain
         run: cp static/CNAME dist/observable/

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -63,6 +63,7 @@ jobs:
         run: echo "data loader check bypassed — i loader sono manuali e tracciati in git"
 
       - name: Build
-        run: npx observable build
-        # Se la cache OF ha fatto match, i data loader vengono saltati
-        # e il build usa solo i JSON in cache + bundle JS (~30s).
+        run: npm run build
+        # generate-config.mjs (prebuild) genera la sidebar da themes.json + catalog.json
+        # Poi observable build esegue i data loader e produce l'output statico.
+        # Se la cache OF ha fatto match, i loader vengono saltati (~30s).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,16 @@ Apri http://localhost:3000
    - primo blocco: distribuzione o stock base, non ranking o delta
    - sezione **Limiti** obbligatoria in fondo (copertura, granularità, note metodologiche)
    - vedi `docs/dataset-page-standard.md` per i principi guida
-3. **Registra** la pagina in `observablehq.config.js` nella sezione `pages`
-4. **Tema**: se il dataset introduce un nuovo tema, aggiungilo in `src/data/themes.json.py`
-5. **Verifica** con `npm run dev` che la pagina sia navigabile e i dati si carichino
-6. **Checklist pre-pub** (nel template, in fondo): verificare slug, parquet, frontmatter,
+3. **Tema**: assegna il dataset a un tema in `src/data/themes.json.py` (o creane uno nuovo).
+    La sidebar (`observablehq.config.js`) si auto-genera da `themes.json` a build time
+    tramite `scripts/generate-config.mjs` — non serve modificarla a mano.
+4. **Verifica** con `npm run dev` che la pagina sia navigabile e i dati si carichino
+5. **Checklist pre-pub** (nel template, in fondo): verificare slug, parquet, frontmatter,
    uso moduli condivisi, leggibilità, link funzionanti
+
+> **Nota**: un dataset pubblicato nel catalogo DI ma senza tema e senza pagina `.md`
+> in explorer viene ignorato dalla sidebar con un warning in console. Appena crei
+> la pagina e la aggiungi al tema, compare automaticamente al prossimo build.
 
 ### Moduli condivisi (`src/import/`)
 

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -4,60 +4,117 @@ export default {
   title: "DataCivicLab Explorer",
   theme: ["air", "ocean-floor"],
   pages: [
-    {
-      name: "Territorio e ambiente",
-      collapsible: true,
-      pages: [
-        { name: "Rifiuti urbani", path: "/dataset/rifiuti-urbani" },
-        { name: "Capacità rinnovabile", path: "/dataset/capacita-rinnovabile" },
-        { name: "Produzione elettrica", path: "/dataset/produzione-elettrica-fonti" },
-        { name: "Incidenti stradali", path: "/dataset/mit-incidentalita" },
-      ],
-    },
-    {
-      name: "Finanza pubblica",
-      collapsible: true,
-      pages: [
-        { name: "IRPEF comunale", path: "/dataset/irpef-comunale" },
-        { name: "Entrate dello Stato", path: "/dataset/entrate-stato" },
-        { name: "Consumi Consip", path: "/dataset/consip-consumi-convenzione" },
-        { name: "Fondo Solidarietà Comunale", path: "/dataset/opencivitas-fsc-2025" },
-        { name: "Indice di Gini regionale", path: "/dataset/istat-gini-regionale" },
-      ],
-    },
-    {
-      name: "Sanità",
-      collapsible: true,
-      pages: [
-        { name: "Spesa farmaceutica", path: "/dataset/spesa-farmaceutica" },
-        { name: "Spesa sanitaria LEA", path: "/dataset/bdap-lea" },
-      ],
-    },
-    {
-      name: "Welfare e lavoro",
-      collapsible: true,
-      pages: [
-        { name: "Dipendenti pubblici", path: "/dataset/dipendenti-pubblici" },
-        { name: "Pensioni INPS", path: "/dataset/pensioni-inps" },
-        { name: "Indice prezzi IPAB", path: "/dataset/istat-ipab-aree" },
-        { name: "Alunni corso/età", path: "/dataset/mim-alunni-corso-eta" },
-        { name: "Popolazione per età", path: "/dataset/popolazione-istat" },
-        { name: "Densità abitativa", path: "/dataset/housing-crowding" },
-      ],
-    },
-    {
-      name: "Giustizia",
-      collapsible: true,
-      pages: [
-        { name: "Flussi giustizia", path: "/dataset/flussi-giustizia-civile" },
-      ],
-    },
-    {
-      name: "Altri dataset",
-      collapsible: true,
-      pages: [
-        { name: "Votazioni Camera", path: "/dataset/votazioni-camera" },
-      ],
-    },
-  ],
+  {
+    "name": "Territorio e ambiente",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "Rifiuti urbani nei comuni",
+        "path": "/dataset/rifiuti-urbani"
+      },
+      {
+        "name": "Capacità rinnovabile per regione",
+        "path": "/dataset/capacita-rinnovabile"
+      },
+      {
+        "name": "Produzione elettrica per fonte",
+        "path": "/dataset/produzione-elettrica-fonti"
+      },
+      {
+        "name": "Incidenti stradali",
+        "path": "/dataset/mit-incidentalita"
+      }
+    ]
+  },
+  {
+    "name": "Finanza pubblica",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "IRPEF comunale",
+        "path": "/dataset/irpef-comunale"
+      },
+      {
+        "name": "Entrate dello Stato",
+        "path": "/dataset/entrate-stato"
+      },
+      {
+        "name": "Consumi in convenzione Consip",
+        "path": "/dataset/consip-consumi-convenzione"
+      },
+      {
+        "name": "Indice di Gini regionale",
+        "path": "/dataset/istat-gini-regionale"
+      },
+      {
+        "name": "Fondo di Solidarietà Comunale 2025",
+        "path": "/dataset/opencivitas-fsc-2025"
+      }
+    ]
+  },
+  {
+    "name": "Sanità",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "Spesa farmaceutica convenzionata",
+        "path": "/dataset/spesa-farmaceutica"
+      },
+      {
+        "name": "Spesa sanitaria regionale LEA",
+        "path": "/dataset/bdap-lea"
+      }
+    ]
+  },
+  {
+    "name": "Welfare e lavoro",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "Dipendenti pubblici per comparto",
+        "path": "/dataset/dipendenti-pubblici"
+      },
+      {
+        "name": "Pensioni INPS",
+        "path": "/dataset/pensioni-inps"
+      },
+      {
+        "name": "Indice prezzi abitazioni (IPAB) per area",
+        "path": "/dataset/istat-ipab-aree"
+      },
+      {
+        "name": "Alunni per corso ed età",
+        "path": "/dataset/mim-alunni-corso-eta"
+      },
+      {
+        "name": "Popolazione italiana per età",
+        "path": "/dataset/popolazione-istat"
+      },
+      {
+        "name": "Densità abitativa",
+        "path": "/dataset/housing-crowding"
+      }
+    ]
+  },
+  {
+    "name": "Giustizia",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "Flussi della giustizia civile",
+        "path": "/dataset/flussi-giustizia-civile"
+      }
+    ]
+  },
+  {
+    "name": "Altri dataset",
+    "collapsible": true,
+    "pages": [
+      {
+        "name": "Votazioni Camera dei Deputati",
+        "path": "/dataset/votazioni-camera"
+      }
+    ]
+  }
+],
 };

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/generate-config.mjs && observable build",
-    "dev": "observable preview",
-    "preview": "observable preview",
+    "dev": "node scripts/generate-config.mjs && observable preview",
+    "preview": "node scripts/generate-config.mjs && observable preview",
     "generate:catalog": "node scripts/generate_catalog.mjs",
     "generate:config": "node scripts/generate-config.mjs",
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "observable build",
+    "build": "node scripts/generate-config.mjs && observable build",
     "dev": "observable preview",
     "preview": "observable preview",
     "generate:catalog": "node scripts/generate_catalog.mjs",
+    "generate:config": "node scripts/generate-config.mjs",
 
     "test": "node --test tests/*.test.mjs && python3 -m pytest tests/test_util.py -q --tb=short",
     "test:js": "node --test tests/*.test.mjs",

--- a/scripts/generate-config.mjs
+++ b/scripts/generate-config.mjs
@@ -1,0 +1,119 @@
+/**
+ * generate-config.mjs — Genera observablehq.config.js da themes.json + catalog.json.
+ *
+ * Sostituisce la manutenzione manuale della sidebar in observablehq.config.js
+ * con una versione auto-generata dai data loader temi + catalogo.
+ *
+ * Flusso:
+ *   1. Legge themes.json e catalog.json dalla cache OF (src/.observablehq/cache/data/)
+ *   2. Se la cache non esiste (primo build), esegue i loader Python direttamente
+ *   3. Costruisce la sidebar: ogni tema = sezione collassabile, ogni dataset = link
+ *   4. Dataset non assegnati a nessun tema → sezione "Altri dataset"
+ *   5. Scrive observablehq.config.js
+ *
+ * Integrazione: npm run prebuild (eseguito automaticamente prima di npm run build)
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// ── Cache OF o fallback esecuzione diretta ──────────────────────────────────
+
+function readData(slug) {
+  // Prova prima la cache OF (più veloce, evita Python + HTTP)
+  const cachePath = resolve(ROOT, `src/.observablehq/cache/data/${slug}`);
+  if (existsSync(cachePath)) {
+    return JSON.parse(readFileSync(cachePath, "utf-8"));
+  }
+
+  // Fallback: esegue il data loader Python
+  const loaderPath = resolve(ROOT, `src/data/${slug}.py`);
+  if (!existsSync(loaderPath)) {
+    throw new Error(`Data loader non trovato: ${loaderPath}`);
+  }
+  const raw = execSync(`python3 "${loaderPath}"`, {
+    encoding: "utf-8",
+    cwd: ROOT,
+  });
+  return JSON.parse(raw);
+}
+
+// ── Generazione sidebar ─────────────────────────────────────────────────────
+
+function readPageTitle(slug) {
+  /* Legge il title: dal frontmatter YAML della pagina dataset.
+   * I nomi editoriali (es. "Rifiuti urbani") sono lì.
+   * Fallback: lo slug. */
+  const pagePath = resolve(ROOT, `src/dataset/${slug}.md`);
+  if (!existsSync(pagePath)) return slug;
+  const content = readFileSync(pagePath, "utf-8");
+  const match = content.match(/^title:\s*(.+)$/m);
+  return match ? match[1].trim() : slug;
+}
+
+function buildSidebar(themes, catalog) {
+  const pages = themes.map((t) => ({
+    name: t.name,
+    collapsible: true,
+    pages: t.datasets.map((slug) => ({
+      name: readPageTitle(slug),
+      path: `/dataset/${slug}`,
+    })),
+  }));
+
+  // Dataset pubblicati non assegnati a nessun tema → "Altri dataset"
+  // Solo se hanno una pagina .md corrispondente in src/dataset/
+  const assigned = new Set(themes.flatMap((t) => t.datasets));
+  const unassigned = catalog.datasets.filter((d) => {
+    if (d.stage !== "published") return false;
+    if (assigned.has(d.url_slug)) return false;
+    const pagePath = resolve(ROOT, `src/dataset/${d.url_slug}.md`);
+    if (!existsSync(pagePath)) {
+      console.warn(`  ⚠  ${d.url_slug}: pubblicato ma senza pagina explorer (salta)`);
+      return false;
+    }
+    return true;
+  });
+  if (unassigned.length > 0) {
+    pages.push({
+      name: "Altri dataset",
+      collapsible: true,
+      pages: unassigned.map((d) => ({
+        name: readPageTitle(d.url_slug),
+        path: `/dataset/${d.url_slug}`,
+      })),
+    });
+  }
+
+  return pages;
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+try {
+  const catalog = readData("catalog.json");
+  const themes = readData("themes.json");
+
+  const pages = buildSidebar(themes, catalog);
+
+  const config = `export default {
+  root: "src",
+  output: "dist/observable",
+  title: "DataCivicLab Explorer",
+  theme: ["air", "ocean-floor"],
+  pages: ${JSON.stringify(pages, null, 2)},
+};
+`;
+
+  const configPath = resolve(ROOT, "observablehq.config.js");
+  writeFileSync(configPath, config, "utf-8");
+  console.log(`✓ generate-config: ${pages.length} sezioni, ${pages.flatMap(p => p.pages || []).length} dataset`);
+} catch (err) {
+  console.error("✗ generate-config fallito:", err.message);
+  process.exit(1);
+}

--- a/src/index.md
+++ b/src/index.md
@@ -35,6 +35,10 @@ display(html`<div class="grid grid-cols-2">
 ## Tutti i dataset
 
 ```js
+const searchQuery = view(Inputs.search(catalog.datasets, {label: "Cerca per nome, descrizione o fonte…"}));
+```
+
+```js
 const stageFilter = view(Inputs.select(
   ["Tutti", "published", "incubating"],
   {label: "Filtra per stato", value: "Tutti"}
@@ -42,9 +46,7 @@ const stageFilter = view(Inputs.select(
 ```
 
 ```js
-const filtered = stageFilter === "Tutti"
-  ? catalog.datasets
-  : catalog.datasets.filter(d => d.stage === stageFilter);
+const filtered = searchQuery.filter(d => stageFilter === "Tutti" || d.stage === stageFilter);
 ```
 
 ```js


### PR DESCRIPTION
## Sintesi

**Fase 4** — La sidebar (`observablehq.config.js`) ora si auto-genera da `themes.json` + `catalog.json` a build time. Niente più manutenzione manuale.

**Fase 5** — Barra di ricerca full-text sulla home page per filtrare i dataset.

## Contesto collegato

Completa Fase 4 e 5 del piano architetturale.

## Cosa cambia

- [ ] Nuovo dataset — pagina explorer
- [ ] Bug fix frontend (data loader / layout / performance)
- [x] Aggiornamento config / catalogo
- [ ] Modifica struttura dati upstream
- [x] Documentazione
- [ ] Dipendenze o CI

## Dettaglio

### Fase 4 — Sidebar auto-generata

`scripts/generate-config.mjs`:
1. Legge `themes.json` e `catalog.json` dalla cache OF (o esegue i loader Python)
2. Per ogni tema, elenca i dataset con nome editoriale (dal `title:` frontmatter della pagina `.md`)
3. Dataset pubblicati senza tema → sezione "Altri dataset" (solo se hanno pagina `.md`)
4. Dataset pubblicati senza pagina `.md` → warning in console, saltati
5. Genera `observablehq.config.js`

Integrazione: `"build": "node scripts/generate-config.mjs && observable build"` in `package.json`.
I workflow `deploy.yml` e `pr-check.yml` ora usano `npm run build`.

**Per aggiungere un dataset**: basta creare pagina `.md` + aggiungere a `themes.json.py`. La sidebar si aggiorna da sola.

### Fase 5 — Search

`Inputs.search()` sulla tabella dataset in `src/index.md`. Filtra in tempo reale su nome, descrizione, fonte.

### Documentazione

`CONTRIBUTING.md`: step "Registra in observablehq.config.js" rimosso.

## Verifica

```bash
npm test        # 51 JS + 12 Python ✅
npm run lint    # OK ✅
npm run build   # 27 pagine, 0 errori, 21 link ✅
                # generate-config: 6 sezioni, 19 dataset
                # 12 warning per dataset pubblicati senza pagina explorer
```

## Checklist PR

- [x] Perimetro stretto: sidebar auto-generata + search
