### PR TITLE
feat: spese dello Stato BDAP — pagina explorer

### DIFF
--- a/src/data/bdap-spese-stato.json.py
+++ b/src/data/bdap-spese-stato.json.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Data loader: BDAP Spese Stato — previsioni definitive per amministrazione e missione.
+
+Singolo file parquet multi-anno (2008-2024)."""
+import sys; sys.path.insert(0, "src/data")
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.paths import https_url, CLEAN_BUCKET
+import json
+
+slug = "bdap_spese_stato"
+year = 2024
+
+if not object_exists(CLEAN_BUCKET, f"{slug}/{year}/{slug}_{year}_clean.parquet"):
+    json.dump([], sys.stdout)
+    sys.exit(0)
+
+url = https_url("clean", "clean_parquet", slug=slug, year=year)
+
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT esercizio_finanziario, amministrazione, missione,
+               SUM(previsioni_definitive_cp) AS spesa_cp,
+               SUM(previsioni_definitive_cs) AS spesa_cs
+        FROM read_parquet('{url}')
+        GROUP BY esercizio_finanziario, amministrazione, missione
+        ORDER BY esercizio_finanziario, amministrazione
+    """).fetchall()
+
+data = [
+    {"anno": int(r[0]), "amministrazione": r[1], "missione": r[2],
+     "spesa_cp": float(r[3]) if r[3] else 0,
+     "spesa_cs": float(r[4]) if r[4] else 0}
+    for r in rows
+]
+
+json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -13,7 +13,7 @@ themes = [
         "slug": "finanza-pubblica",
         "name": "Finanza pubblica",
         "description": "Entrate dello Stato, capacità fiscale, tributi locali, FSC, partecipazioni PA e disuguaglianza del reddito",
-        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione", "istat-gini-regionale", "opencivitas-fsc-2025", "mef-partecipazioni"],
+        "datasets": ["irpef-comunale", "entrate-stato", "consip-consumi-convenzione", "istat-gini-regionale", "opencivitas-fsc-2025", "mef-partecipazioni", "bdap-spese-stato"],
     },
     {
         "slug": "sanita",

--- a/src/dataset/bdap-spese-stato.md
+++ b/src/dataset/bdap-spese-stato.md
@@ -1,0 +1,189 @@
+---
+title: Spese dello Stato
+description: Previsioni definitive di spesa per amministrazione e missione — BDAP, 2008-2024
+source: MEF — BDAP
+source_url: https://www.rgs.mef.gov.it/
+period: "2008–2024"
+last_modified: 2026-06-10
+dataset_slug: bdap_spese_stato
+---
+
+# Spese dello Stato
+
+Previsioni definitive di spesa delle amministrazioni statali italiane, per amministrazione e missione. I dati mostrano chi spende e in cosa, dal 2008 al 2024.
+
+**Fonte**: [MEF — BDAP](https://www.rgs.mef.gov.it/) · **Periodo**: 2008–2024
+
+```js
+import { num, euroCompact, tableFormat } from "../import/format-utils.js";
+```
+
+```js
+const data = await FileAttachment("../data/bdap-spese-stato.json").json();
+```
+
+```js
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const filtered = data.filter(d => d.anno === annoSel);
+const totSpesa = d3.sum(filtered, d => d.spesa_cp);
+const nAmm = new Set(filtered.map(d => d.amministrazione)).size;
+const nMissioni = new Set(filtered.map(d => d.missione)).size;
+
+// Spesa per amministrazione
+const perAmm = Array.from(
+  d3.rollup(filtered, v => d3.sum(v, d => d.spesa_cp), d => d.amministrazione),
+  ([amministrazione, spesa_cp]) => ({amministrazione, spesa_cp})
+).sort((a, b) => b.spesa_cp - a.spesa_cp);
+
+// Spesa per missione
+const perMissione = Array.from(
+  d3.rollup(filtered, v => d3.sum(v, d => d.spesa_cp), d => d.missione),
+  ([missione, spesa_cp]) => ({missione, spesa_cp})
+).sort((a, b) => b.spesa_cp - a.spesa_cp).slice(0, 15);
+
+// Trend totale
+const trend = Array.from(
+  d3.rollup(data, v => d3.sum(v, d => d.spesa_cp), d => d.anno),
+  ([anno, spesa_cp]) => ({anno, spesa_cp})
+).sort((a, b) => a.anno - b.anno);
+
+// Delta 2008→2024
+const spesa2008 = trend.find(d => d.anno === 2008)?.spesa_cp || 0;
+const spesa2024 = trend.find(d => d.anno === 2024)?.spesa_cp || 0;
+const deltaPct = spesa2008 ? Math.round((spesa2024 - spesa2008) / spesa2008 * 1000) / 10 : 0;
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Spesa totale</h3>
+    <span class="big">${euroCompact(totSpesa)}</span>
+    <small style="opacity:0.6">${String(annoSel)}</small>
+  </div>
+  <div class="card">
+    <h3>Amministrazioni</h3>
+    <span class="big">${nAmm}</span>
+  </div>
+  <div class="card">
+    <h3>Missioni</h3>
+    <span class="big">${nMissioni}</span>
+  </div>
+</div>
+
+---
+
+## Evoluzione della spesa 2008-2024
+
+La spesa statale totale è cresciuta da €748 mld nel 2008 a oltre €1.245 mld nel 2024 (+${deltaPct}%). Il salto del 2020 riflette le misure pandemiche.
+
+```js
+Plot.plot({
+  title: "Previsioni definitive di spesa — 2008-2024",
+  width: 800,
+  height: 350,
+  x: {tickFormat: d => String(d), label: null},
+  y: {grid: true, tickFormat: "~s", label: "Spesa (€)"},
+  marks: [
+    Plot.lineY(trend, {x: "anno", y: "spesa_cp", tip: {format: {y: d => euroCompact(d)}}}),
+    Plot.dot(trend, {x: "anno", y: "spesa_cp", fill: "steelblue", r: 3}),
+    Plot.areaY(trend, {x: "anno", y: "spesa_cp", fill: "steelblue", fillOpacity: 0.05}),
+    Plot.ruleY([0])
+  ]
+})
+```
+
+---
+
+## Spesa per amministrazione — ${String(annoSel)}
+
+```js
+Plot.plot({
+  title: `Spesa per amministrazione — ${String(annoSel)}`,
+  width: 800,
+  height: 400,
+  marginLeft: 220,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Blues"},
+  marks: [
+    Plot.barX(perAmm, {
+      y: "amministrazione",
+      x: "spesa_cp",
+      fill: "spesa_cp",
+      sort: {y: "-x"},
+      tip: {format: {x: d => euroCompact(d)}}
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Spesa per missione — ${String(annoSel)}
+
+```js
+Plot.plot({
+  title: `Spesa per missione — ${String(annoSel)}`,
+  width: 800,
+  height: 400,
+  marginLeft: 220,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Oranges"},
+  marks: [
+    Plot.barX(perMissione, {
+      y: "missione",
+      x: "spesa_cp",
+      fill: "spesa_cp",
+      sort: {y: "-x"},
+      tip: {format: {x: d => euroCompact(d)}}
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Dettaglio per amministrazione e missione
+
+```js
+const { header, format } = tableFormat({
+  amministrazione: { label: "Amministrazione", fmt: "string" },
+  missione: { label: "Missione", fmt: "string" },
+  spesa_cp: { label: "Spesa (cp)", fmt: "euroCompact" },
+  spesa_cs: { label: "Spesa (cs)", fmt: "euroCompact" },
+});
+```
+
+```js
+Inputs.table(filtered, {
+  columns: ["amministrazione", "missione", "spesa_cp", "spesa_cs"],
+  header,
+  format,
+  rows: 20,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: la serie copre il periodo 2008-2024. Tutti i dati provengono da un unico file BDAP.
+- **Previsioni definitive**: i dati sono previsioni di spesa definitive, non spese effettivamente sostenute. Possono differire dai consuntivi.
+- **Amministrazioni**: la denominazione delle amministrazioni può cambiare nel periodo (es. fusioni, scissioni di ministeri). I dati riflettono la denominazione al momento della previsione.
+- **Missioni**: la classificazione per missione segue il COFOG (Classificazione delle Funzioni di Governo). Alcune missioni hanno denominazioni leggermente variabili negli anni.
+
+---
+
+## Risorse
+
+- [MEF — BDAP](https://www.rgs.mef.gov.it/)
+- [Esplora i dati con Query SQL](https://dataciviclab-dashboard.streamlit.app/Query_SQL)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/bdap_spese_stato/2024/bdap_spese_stato_2024_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/bdap-spese-stato)

--- a/src/dataset/bdap-spese-stato.md
+++ b/src/dataset/bdap-spese-stato.md
@@ -23,37 +23,37 @@ const data = await FileAttachment("../data/bdap-spese-stato.json").json();
 ```
 
 ```js
-const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const anni = [...new Set(data.map(d => d.esercizio_finanziario))].sort((a, b) => b - a);
 const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
 ```
 
 ```js
-const filtered = data.filter(d => d.anno === annoSel);
-const totSpesa = d3.sum(filtered, d => d.spesa_cp);
+const filtered = data.filter(d => d.esercizio_finanziario === annoSel);
+const totSpesa = d3.sum(filtered, d => d.previsioni_definitive_cp);
 const nAmm = new Set(filtered.map(d => d.amministrazione)).size;
 const nMissioni = new Set(filtered.map(d => d.missione)).size;
 
 // Spesa per amministrazione
 const perAmm = Array.from(
-  d3.rollup(filtered, v => d3.sum(v, d => d.spesa_cp), d => d.amministrazione),
-  ([amministrazione, spesa_cp]) => ({amministrazione, spesa_cp})
-).sort((a, b) => b.spesa_cp - a.spesa_cp);
+  d3.rollup(filtered, v => d3.sum(v, d => d.previsioni_definitive_cp), d => d.amministrazione),
+  ([amministrazione, spesa]) => ({amministrazione, spesa})
+).sort((a, b) => b.spesa - a.spesa);
 
 // Spesa per missione
 const perMissione = Array.from(
-  d3.rollup(filtered, v => d3.sum(v, d => d.spesa_cp), d => d.missione),
-  ([missione, spesa_cp]) => ({missione, spesa_cp})
-).sort((a, b) => b.spesa_cp - a.spesa_cp).slice(0, 15);
+  d3.rollup(filtered, v => d3.sum(v, d => d.previsioni_definitive_cp), d => d.missione),
+  ([missione, spesa]) => ({missione, spesa})
+).sort((a, b) => b.spesa - a.spesa).slice(0, 15);
 
 // Trend totale
 const trend = Array.from(
-  d3.rollup(data, v => d3.sum(v, d => d.spesa_cp), d => d.anno),
-  ([anno, spesa_cp]) => ({anno, spesa_cp})
-).sort((a, b) => a.anno - b.anno);
+  d3.rollup(data, v => d3.sum(v, d => d.previsioni_definitive_cp), d => d.esercizio_finanziario),
+  ([esercizio_finanziario, spesa]) => ({esercizio_finanziario, spesa})
+).sort((a, b) => a.esercizio_finanziario - b.esercizio_finanziario);
 
 // Delta 2008→2024
-const spesa2008 = trend.find(d => d.anno === 2008)?.spesa_cp || 0;
-const spesa2024 = trend.find(d => d.anno === 2024)?.spesa_cp || 0;
+const spesa2008 = trend.find(d => d.esercizio_finanziario === 2008)?.spesa || 0;
+const spesa2024 = trend.find(d => d.esercizio_finanziario === 2024)?.spesa || 0;
 const deltaPct = spesa2008 ? Math.round((spesa2024 - spesa2008) / spesa2008 * 1000) / 10 : 0;
 ```
 
@@ -87,9 +87,9 @@ Plot.plot({
   x: {tickFormat: d => String(d), label: null},
   y: {grid: true, tickFormat: "~s", label: "Spesa (€)"},
   marks: [
-    Plot.lineY(trend, {x: "anno", y: "spesa_cp", tip: {format: {y: d => euroCompact(d)}}}),
-    Plot.dot(trend, {x: "anno", y: "spesa_cp", fill: "steelblue", r: 3}),
-    Plot.areaY(trend, {x: "anno", y: "spesa_cp", fill: "steelblue", fillOpacity: 0.05}),
+    Plot.lineY(trend, {x: "esercizio_finanziario", y: "spesa", tip: {format: {y: d => euroCompact(d)}}}),
+    Plot.dot(trend, {x: "esercizio_finanziario", y: "spesa", fill: "steelblue", r: 3}),
+    Plot.areaY(trend, {x: "esercizio_finanziario", y: "spesa", fill: "steelblue", fillOpacity: 0.05}),
     Plot.ruleY([0])
   ]
 })
@@ -111,8 +111,8 @@ Plot.plot({
   marks: [
     Plot.barX(perAmm, {
       y: "amministrazione",
-      x: "spesa_cp",
-      fill: "spesa_cp",
+      x: "spesa",
+      fill: "spesa",
       sort: {y: "-x"},
       tip: {format: {x: d => euroCompact(d)}}
     }),
@@ -137,8 +137,8 @@ Plot.plot({
   marks: [
     Plot.barX(perMissione, {
       y: "missione",
-      x: "spesa_cp",
-      fill: "spesa_cp",
+      x: "spesa",
+      fill: "spesa",
       sort: {y: "-x"},
       tip: {format: {x: d => euroCompact(d)}}
     }),
@@ -155,14 +155,14 @@ Plot.plot({
 const { header, format } = tableFormat({
   amministrazione: { label: "Amministrazione", fmt: "string" },
   missione: { label: "Missione", fmt: "string" },
-  spesa_cp: { label: "Spesa (cp)", fmt: "euroCompact" },
-  spesa_cs: { label: "Spesa (cs)", fmt: "euroCompact" },
+  previsioni_definitive_cp: { label: "Spesa (cp)", fmt: "euroCompact" },
+  previsioni_definitive_cs: { label: "Spesa (cs)", fmt: "euroCompact" },
 });
 ```
 
 ```js
 Inputs.table(filtered, {
-  columns: ["amministrazione", "missione", "spesa_cp", "spesa_cs"],
+  columns: ["amministrazione", "missione", "previsioni_definitive_cp", "previsioni_definitive_cs"],
   header,
   format,
   rows: 20,


### PR DESCRIPTION
## Sintesi

Pagina dataset per **Spese dello Stato** — previsioni definitive di spesa delle amministrazioni statali, da BDAP (2008-2024).

## Dettaglio

### File

- `src/data/bdap-spese-stato.json.py` — Loader: aggregazione per anno × amministrazione × missione (SUM)
- `src/dataset/bdap-spese-stato.md` — Pagina con 4 blocchi
- `src/data/themes.json.py` — Aggiunto a **Finanza pubblica**

### Struttura pagina

1. **Scorecards**: spesa totale, n. amministrazioni, n. missioni
2. **Trend**: line chart spesa totale 2008-2024 (salto COVID ben visibile)
3. **Spesa per amministrazione**: bar chart top amministrazioni (MEF domina)
4. **Spesa per missione**: bar chart top missioni (Debito pubblico, Previdenza)
5. **Tabella**: dettaglio × amministrazione + missione

### Dati

- 17 anni (2008-2024), 11.881 righe, 26 amministrazioni, 34 missioni
- Spesa 2008: €748 mld → 2024: €1.245 mld (+66%)

## Verifica

```bash
npm test          # pass
npm run lint      # pass
npm run build     # 28 pagine, 0 errori, 21 link
```

## Checklist

- [x] Data loader
- [x] Pagina
- [x] Tema: Finanza pubblica
- [x] Moduli condivisi: `format-utils.js`
- [x] Sidebar auto-generata
