### PR TITLE
feat: buildMapLookup wrapper + mappe per consip, spesa, mim-alunni

### DIFF
--- a/src/dataset/bdap-lea.md
+++ b/src/dataset/bdap-lea.md
@@ -15,7 +15,7 @@ I costi sostenuti dalle regioni italiane per garantire i Livelli Essenziali di A
 **Fonte**: [BDAP](https://bdap-opendata.rgs.mef.gov.it/) · **Periodo**: 2019–2024
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, euroCompact, tableFormat } from "../import/format-utils.js";
 ```
 
@@ -42,7 +42,7 @@ const totSpesa = d3.sum(regFiltered, d => d.importo_totale);
 const nRegioni = regFiltered.length;
 
 // Per la mappa
-const regLookup = buildRegLookup(regFiltered, "descrizione_regione", "importo_totale");
+const regLookup = buildMapLookup(regFiltered, regioniGeo, "descrizione_regione", "importo_totale");
 
 // Trend spesa totale 2019-2024
 const trend = Array.from(

--- a/src/dataset/capacita-rinnovabile.md
+++ b/src/dataset/capacita-rinnovabile.md
@@ -15,7 +15,7 @@ Dati Terna sulla capacità di generazione rinnovabile installata per regione e f
 **Fonte**: [Terna](https://www.terna.it/) · **Periodo**: 2015–2024
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, unit } from "../import/format-utils.js";
 ```
 
@@ -58,7 +58,7 @@ const perRegione = Array.from(
   d3.rollup(filtered, v => d3.sum(v, d => d.potenza_mw), d => d.regione),
   ([regione, potenza_mw]) => ({regione, potenza_mw})
 ).sort((a, b) => b.potenza_mw - a.potenza_mw);
-const regLookup = buildRegLookup(perRegione, "regione", "potenza_mw");
+const regLookup = buildMapLookup(perRegione, regioniGeo, "regione", "potenza_mw");
 ```
 
 ```js

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -134,6 +134,9 @@ const { header, format } = tableFormat({
   valore_economico_consumi: { label: "Spesa (€)", fmt: "euro" },
   numero_ordini_con_consumi: { label: "Ordini", fmt: "num" },
 });
+```
+
+```js
 Inputs.table(regFiltered, {
   columns: ["regione_pa", "valore_economico_consumi", "numero_ordini_con_consumi"],
   header,

--- a/src/dataset/consip-consumi-convenzione.md
+++ b/src/dataset/consip-consumi-convenzione.md
@@ -16,6 +16,12 @@ La spesa della Pubblica Amministrazione per beni e servizi acquistati attraverso
 
 ```js
 import { num, euro, tableFormat } from "../import/format-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
+```
+
+```js
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -58,26 +64,27 @@ Quali regioni concentrano la spesa in convenzione? Il Lazio e la Lombardia guida
 const regFiltered = regioni
   .filter(d => d.anno_riferimento === annoSel)
   .sort((a, b) => b.valore_economico_consumi - a.valore_economico_consumi);
+const lookup = buildMapLookup(regFiltered, regioniGeo, "regione_pa", "valore_economico_consumi");
 ```
 
 ```js
 Plot.plot({
   title: `Spesa Consip per regione della PA — ${annoSel}`,
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 420,
-  marginLeft: 140,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, label: "milioni di €", tickFormat: d => (d / 1e6).toFixed(0)},
-  color: {scheme: "Oranges"},
+  height: 600,
+  color: {scheme: "Blues", legend: true, label: "Spesa (€)", type: "quantile"},
   marks: [
-    Plot.barX(regFiltered, {
-      y: "regione_pa",
-      x: "valore_economico_consumi",
-      fill: "valore_economico_consumi",
-      sort: {y: "-x"},
-      tip: true
+    Plot.geo(regioniGeo, {
+      fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#888",
+      strokeWidth: 0.25,
+      tip: {format: {fill: d => euro(d)}}
     }),
-    Plot.ruleX([0])
+    Plot.geo(confiniReg, {
+      stroke: "#888",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```

--- a/src/dataset/dipendenti-pubblici.md
+++ b/src/dataset/dipendenti-pubblici.md
@@ -122,6 +122,9 @@ const { header, format } = tableFormat({
   uomini: { label: "Uomini", fmt: "num" },
   totale: { label: "Totale", fmt: "num" },
 });
+```
+
+```js
 Inputs.table(filtered, {
   columns: ["anno", "comparto", "donne", "uomini", "totale"],
   header,

--- a/src/dataset/flussi-giustizia-civile.md
+++ b/src/dataset/flussi-giustizia-civile.md
@@ -146,6 +146,9 @@ const { header, format } = tableFormat({
   pendenti_finali: { label: "Pendenti", fmt: "num" },
   rapporto_def_sop: { label: "Rapporto D/S", fmt: "string" },
 });
+```
+
+```js
 Inputs.table(filtered, {
   columns: ["distretto", "sopravvenuti", "definiti_totale", "pendenti_finali", "rapporto_def_sop"],
   header,

--- a/src/dataset/istat-gini-regionale.md
+++ b/src/dataset/istat-gini-regionale.md
@@ -15,7 +15,7 @@ Disuguaglianza del reddito netto per regione, misurata con l'indice di Gini. I d
 **Fonte**: [ISTAT](https://esploradati.istat.it/) · **Periodo**: 2003–2024
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { numFix, tableFormat } from "../import/format-utils.js";
 ```
 
@@ -50,7 +50,7 @@ const annoDataRegioni = annoData.filter(d => !d.regione.startsWith('Provincia Au
 const mediaRegionale = d3.mean(annoDataRegioni, d => d.gini);
 
 // Lookup per mappa con normalizzazione automatica
-const giniLookup = buildRegLookup(annoDataRegioni, "regione", "gini");
+const giniLookup = buildMapLookup(annoDataRegioni, regioniGeo, "regione", "gini");
 ```
 
 ```js

--- a/src/dataset/mim-alunni-corso-eta.md
+++ b/src/dataset/mim-alunni-corso-eta.md
@@ -16,6 +16,12 @@ Alunni delle scuole statali italiane per ordine scolastico (primaria, secondaria
 
 ```js
 import { num, tableFormat } from "../import/format-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
+```
+
+```js
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -47,6 +53,7 @@ const perRegione = Array.from(
   d3.rollup(filtered, v => d3.sum(v, d => d.alunni), d => d.regione),
   ([regione, alunni]) => ({regione, alunni})
 ).sort((a, b) => b.alunni - a.alunni);
+const lookup = buildMapLookup(perRegione, regioniGeo, "regione", "alunni");
 ```
 
 <div class="grid grid-cols-3">
@@ -115,21 +122,21 @@ Quali regioni hanno più studenti? La classifica segue la popolazione residente,
 ```js
 Plot.plot({
   title: `Alunni per regione — anno ${String(annoSel)}/${String(annoSel+1)}`,
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 450,
-  marginLeft: 120,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Blues"},
+  height: 600,
+  color: {scheme: "Blues", legend: true, label: "Alunni", type: "quantile"},
   marks: [
-    Plot.barX(perRegione, {
-      y: "regione",
-      x: "alunni",
-      fill: "alunni",
-      sort: {y: "-x"},
-      tip: true
+    Plot.geo(regioniGeo, {
+      fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#888",
+      strokeWidth: 0.25,
+      tip: {format: {fill: d => num(d)}}
     }),
-    Plot.ruleX([0])
+    Plot.geo(confiniReg, {
+      stroke: "#888",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```

--- a/src/dataset/mim-alunni-corso-eta.md
+++ b/src/dataset/mim-alunni-corso-eta.md
@@ -163,6 +163,9 @@ const { header, format } = tableFormat({
   "SCUOLA SECONDARIA I GRADO": { label: "Secondaria I", fmt: "num" },
   "SCUOLA SECONDARIA II GRADO": { label: "Secondaria II", fmt: "num" },
 });
+```
+
+```js
 Inputs.table(pivot, {
   columns: ["regione", "SCUOLA PRIMARIA", "SCUOLA SECONDARIA I GRADO", "SCUOLA SECONDARIA II GRADO"],
   header,

--- a/src/dataset/opencivitas-fsc-2025.md
+++ b/src/dataset/opencivitas-fsc-2025.md
@@ -15,7 +15,7 @@ Fondo di Solidarietà Comunale (FSC) 2025 per comune: capacità fiscale, fondo p
 **Fonte**: [OpenCivitas](https://www.opencivitas.it/) · **Periodo**: 2025
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, euroCompact, tableFormat } from "../import/format-utils.js";
 ```
 
@@ -75,7 +75,7 @@ const percContribNetti = (contribNetti / nComuni * 100).toFixed(1);
 ## Dotazione FSC per regione
 
 ```js
-const fscLookup = buildRegLookup(perRegione, "regione", "fsc");
+const fscLookup = buildMapLookup(perRegione, regioniGeo, "regione", "fsc");
 ```
 
 ```js

--- a/src/dataset/popolazione-istat.md
+++ b/src/dataset/popolazione-istat.md
@@ -167,6 +167,9 @@ const { header, format } = tableFormat({
   totale_maschi: { label: "Maschi", fmt: "num" },
   totale_femmine: { label: "Femmine", fmt: "num" },
 });
+```
+
+```js
 Inputs.table(filtered, {
   columns: ["fascia_eta", "popolazione_residente", "totale_maschi", "totale_femmine"],
   header,

--- a/src/dataset/produzione-elettrica-fonti.md
+++ b/src/dataset/produzione-elettrica-fonti.md
@@ -15,7 +15,7 @@ Produzione netta di energia elettrica in GWh per fonte e regione. La produzione 
 **Fonte**: [Terna](https://www.terna.it/) · **Periodo**: 2015–2024
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, unit } from "../import/format-utils.js";
 ```
 
@@ -63,7 +63,7 @@ const trendFonti = Array.from(
 ).flat().sort((a, b) => a.anno - b.anno);
 
 // Lookup per mappa
-const regLookup = buildRegLookup(perRegione, "regione", "produzione_gwh");
+const regLookup = buildMapLookup(perRegione, regioniGeo, "regione", "produzione_gwh");
 ```
 
 ```js

--- a/src/dataset/rifiuti-urbani.md
+++ b/src/dataset/rifiuti-urbani.md
@@ -15,7 +15,7 @@ Dati ISPRA sui rifiuti urbani dei comuni italiani. Produzione totale, raccolta d
 **Fonte**: ISPRA · **Periodo**: 2020–2024
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, pct, unit, tableFormat } from "../import/format-utils.js";
 ```
 
@@ -77,7 +77,7 @@ const comuniFiltrati = comuni
 ## Raccolta differenziata per regione
 
 ```js
-const rdLookup = buildRegLookup(regFiltered, "regione", "quota_rd");
+const rdLookup = buildMapLookup(regFiltered, regioniGeo, "regione", "quota_rd");
 ```
 
 ```js

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -16,6 +16,12 @@ Spesa e consumo della farmaceutica convenzionata SSN, disaggregati per regione, 
 
 ```js
 import { num, euro, tableFormat } from "../import/format-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
+```
+
+```js
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
 ```
 
 ```js
@@ -36,6 +42,7 @@ const perRegione = Array.from(d3.rollup(filtered, v => ({
   spesa: d3.sum(v, d => d.spesa_convenzionata),
   confezioni: d3.sum(v, d => d.numero_confezioni_convenzionata)
 }), d => d.regione), ([regione, v]) => ({regione, ...v})).sort((a,b) => b.spesa - a.spesa);
+const lookup = buildMapLookup(perRegione, regioniGeo, "regione", "spesa");
 ```
 
 ```js
@@ -114,21 +121,21 @@ Come si distribuisce la spesa farmaceutica tra le regioni? Le regioni più popol
 ```js
 Plot.plot({
   title: `Spesa convenzionata per regione — ${annoSel}`,
+  projection: {type: "mercator", domain: regioniGeo},
   width: 800,
-  height: 400,
-  marginLeft: 120,
-  y: {label: null, tickSize: 0},
-  x: {grid: true, tickFormat: "~s"},
-  color: {scheme: "Oranges"},
+  height: 600,
+  color: {scheme: "Blues", legend: true, label: "Spesa (€)", type: "quantile"},
   marks: [
-    Plot.barX(perRegione, {
-      y: "regione",
-      x: "spesa",
-      fill: "spesa",
-      sort: {y: "-x"},
-      tip: true
+    Plot.geo(regioniGeo, {
+      fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#888",
+      strokeWidth: 0.25,
+      tip: {format: {fill: d => euro(d)}}
     }),
-    Plot.ruleX([0])
+    Plot.geo(confiniReg, {
+      stroke: "#888",
+      strokeWidth: 0.7
+    })
   ]
 })
 ```

--- a/src/dataset/spesa-farmaceutica.md
+++ b/src/dataset/spesa-farmaceutica.md
@@ -150,6 +150,9 @@ const { header, format } = tableFormat({
   spesa: { label: "Spesa (€)", fmt: "euro" },
   confezioni: { label: "Confezioni", fmt: "num" },
 });
+```
+
+```js
 Inputs.table(perRegione, {
   columns: ["regione", "spesa", "confezioni"],
   header,

--- a/src/import/geo-utils.js
+++ b/src/import/geo-utils.js
@@ -66,27 +66,48 @@ export async function loadItalianRegions(regTopo) {
 }
 
 /**
- * Costruisce una lookup table regione→valore, normalizzando i nomi
- * e applicando fallback per regioni con nomi non standard.
+ * Tokenizza un nome regione per fuzzy matching: toglie punti, slash,
+ * apostrofi e parole comuni, restituisce un set di token significativi.
+ *
+ * @param {string} nome — Nome regione (es. "F.-V. GIULIA")
+ * @returns {string[]} Token significativi (es. ["F", "V", "GIULIA"])
+ */
+function tokenizeReg(nome) {
+  return nome
+    .toUpperCase()
+    .replace(/[.\/']/g, " ")
+    .replace(/-/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter((t) => t.length >= 3 && !STOP_WORDS.has(t));
+}
+
+/** Parole troppo generiche per il matching. */
+const STOP_WORDS = new Set([
+  "ALTO", "ALTA", "ALTI", "BASSO", "BASSA",
+  "DELL", "DELLA", "DELLE", "DEGLI", "DEL", "DEI",
+  "SÜDTIROL", "VALLÉE",
+  "PROVINCIA", "AUTONOMA", "PROV",
+]);
+
+/**
+ * Costruisce una lookup table regione→valore, normalizzando i nomi,
+ * applicando fallback per nomi non standard e fuzzy matching opzionale.
  *
  * @param {Array} data — Array di oggetti con campo regione e campo valore
  * @param {string} keyField — Nome del campo "regione" (default: "regione")
- * @param {string} valueField — Nome del campo valore (default: usato se omitValue è false)
+ * @param {string} valueField — Nome del campo valore
  * @param {Function} [transformValue] — Trasformazione opzionale del valore
- *        Es: d => d.reddito_imponibile_eur / totNazionale * 100
  * @param {Object} [extraFallbacks] — Fallback aggiuntivi oltre a REG_FALLBACKS
+ * @param {string[]} [topoKeys] — Se fornito, attiva il terzo passaggio fuzzy:
+ *        cerca per token comune tra chiavi dataset e nomi TopoJSON non matchati.
  * @returns {Map<string, any>} lookup table
  *
  * @example
- * // Semplice: regione → metrica
- * const lookup = buildRegLookup(dataFiltrati, "regione", "quota_rd");
- *
- * // Con trasformazione: regione → % del totale nazionale
- * const tot = d3.sum(data, d => d.reddito);
- * const lookup = buildRegLookup(data, "regione", null, d => d.reddito / tot * 100);
- *
- * // Con fallback extra
- * const lookup = buildRegLookup(data, "regione", "valore", null, {"P.A. TRENTO": "TRENTINO-ALTO-ADIGE/SÜDTIROL"});
+ * // Con fuzzy matching:
+ * const topoNomi = regioniGeo.features.map(d => d.properties.DEN_REG);
+ * const lookup = buildRegLookup(data, "regione", "valore", null, {}, topoNomi);
  */
 export function buildRegLookup(
   data,
@@ -94,6 +115,7 @@ export function buildRegLookup(
   valueField,
   transformValue,
   extraFallbacks = {},
+  topoKeys = null,
 ) {
   const allFallbacks = { ...REG_FALLBACKS, ...extraFallbacks };
   const lookup = new Map();
@@ -113,13 +135,74 @@ export function buildRegLookup(
     if (lookup.has(shortKey) && !lookup.has(fullKey)) {
       lookup.set(fullKey, lookup.get(shortKey));
     }
-    // Se il dato ha il nome lungo ma shortKey non esiste, copia comunque
     if (lookup.has(fullKey) && !lookup.has(shortKey)) {
       lookup.set(shortKey, lookup.get(fullKey));
     }
   }
 
+  // Terzo pass (opzionale): fuzzy matching per topoKeys ancora senza valore
+  if (topoKeys && topoKeys.length > 0) {
+    // Costruisce un indice tokens→chiavi dataset
+    const tokenIndex = new Map(); // token → [dataKey, ...]
+    for (const dataKey of lookup.keys()) {
+      for (const token of tokenizeReg(dataKey)) {
+        if (!tokenIndex.has(token)) tokenIndex.set(token, []);
+        tokenIndex.get(token).push(dataKey);
+      }
+    }
+
+    for (const topoName of topoKeys) {
+      const topoKey = normalizzaReg(topoName);
+      if (lookup.has(topoKey)) continue; // già matchato
+
+      // Cerca token comuni tra topoName e le chiavi dataset
+      const topoTokens = tokenizeReg(topoName);
+      const candidates = new Set();
+      for (const token of topoTokens) {
+        const matches = tokenIndex.get(token) || [];
+        for (const dk of matches) candidates.add(dk);
+      }
+
+      if (candidates.size === 1) {
+        // Match univoco: assegna il valore
+        const [dataKey] = candidates;
+        lookup.set(topoKey, lookup.get(dataKey));
+      }
+      // Se 0 o più di 1 candidati, non si può determinare — skip
+    }
+  }
+
   return lookup;
+}
+
+/**
+ * buildMapLookup — wrapper standard per mappe coropletiche.
+ * Equivalente a buildRegLookup con topoKeys automatico da regioniGeo.
+ * Elimina il boilerplate: normalizzaReg, features.map, topoKeys manuale.
+ *
+ * @param {Array} data — dati con campo regione
+ * @param {Object} regioniGeo — GeoJSON FeatureCollection (da loadItalianRegions)
+ * @param {string} [keyField="regione"] — campo regione nei dati
+ * @param {string} [valueField] — campo valore
+ * @param {Function} [transformValue] — trasformazione opzionale del valore
+ * @param {Object} [extraFallbacks] — fallback aggiuntivi oltre a REG_FALLBACKS
+ * @returns {Map<string, any>}
+ *
+ * @example
+ * const { regioniGeo } = await loadItalianRegions(regTopo);
+ * const lookup = buildMapLookup(data, regioniGeo, "regione", "valore");
+ * // poi: Plot.geo(regioniGeo, { fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)) })
+ */
+export function buildMapLookup(
+  data,
+  regioniGeo,
+  keyField = "regione",
+  valueField,
+  transformValue,
+  extraFallbacks = {},
+) {
+  const topoKeys = regioniGeo.features.map((d) => d.properties.DEN_REG);
+  return buildRegLookup(data, keyField, valueField, transformValue, extraFallbacks, topoKeys);
 }
 
 /**

--- a/tests/test_shared-utils.test.mjs
+++ b/tests/test_shared-utils.test.mjs
@@ -263,4 +263,42 @@ describe("buildRegLookup()", () => {
     assert.ok(lookup.has("TRENTINO-ALTO-ADIGE/SÜDTIROL"));
     assert.equal(lookup.get("TRENTINO-ALTO-ADIGE/SÜDTIROL"), 50);
   });
+
+  it("fuzzy matching: matcha F.-V. GIULIA a FRIULI-VENEZIA-GIULIA", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [{ regione: "F.-V. GIULIA", valore: 100 }];
+    // Simula topoKeys (TopoJSON DEN_REG)
+    const topoKeys = ["Friuli-Venezia Giulia"];
+    const lookup = buildRegLookup(data, "regione", "valore", null, {}, topoKeys);
+    assert.ok(lookup.has("FRIULI-VENEZIA-GIULIA"), "deve matchare Friuli via token GIULIA");
+    assert.equal(lookup.get("FRIULI-VENEZIA-GIULIA"), 100);
+  });
+
+  it("fuzzy matching: non matcha nomi senza token comune", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    // "XYZ" non ha token comune con nessuna regione TopoJSON
+    const data = [{ regione: "Regione XYZ", valore: 99 }];
+    const topoKeys = ["Lombardia", "Veneto"];
+    const lookup = buildRegLookup(data, "regione", "valore", null, {}, topoKeys);
+    assert.ok(!lookup.has("LOMBARDIA"), "non deve matchare Lombardia");
+    assert.ok(!lookup.has("VENETO"), "non deve matchare Veneto");
+  });
+
+  it("fuzzy matching: P.A. Trento via fallback funziona ancora", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [{ regione: "P. A. TRENTO", valore: 50 }];
+    const topoKeys = ["Trentino-Alto Adige/Südtirol"];
+    // Con REG_FALLBACKS gia' in buildRegLookup, P. A. TRENTO viene mappato
+    const lookup = buildRegLookup(data, "regione", "valore", null, {}, topoKeys);
+    assert.ok(lookup.has("TRENTINO-ALTO-ADIGE/SÜDTIROL"),
+      "P.A. Trento deve matchare Trentino via REG_FALLBACKS");
+  });
+
+  it("fuzzy matching: non inventa match per nomi senza token comune", async () => {
+    const { buildRegLookup } = await import("../src/import/geo-utils.js");
+    const data = [{ regione: "Sconosciuta", valore: 99 }];
+    const topoKeys = ["Lombardia"];
+    const lookup = buildRegLookup(data, "regione", "valore", null, {}, topoKeys);
+    assert.ok(!lookup.has("LOMBARDIA"), "non deve matchare senza token comune");
+  });
 });


### PR DESCRIPTION
## Sintesi

Standard per le mappe coropletiche: `buildMapLookup()` wrapper che prende `regioniGeo` e costruisce automaticamente la lookup con fuzzy matching. Refactor 6 pagine + nuove mappe per 3.

## Cosa cambia

### `geo-utils.js`
- `buildMapLookup(data, regioniGeo, keyField, valueField)` — wrapper standard
- Usa `buildRegLookup` internamente con `topoKeys` automatico da `regioniGeo`
- Elimina il boilerplate `features.map(d => d.properties.DEN_REG)` dalle pagine

### Refactor 6 pagine (buildRegLookup → buildMapLookup)
rifiuti-urbani, istat-gini-regionale, opencivitas-fsc-2025, capacita-rinnovabile, produzione-elettrica-fonti, bdap-lea

### Nuove mappe (3 pagine)
consip-consumi-convenzione, spesa-farmaceutica, mim-alunni-corso-eta

### Fuzzy region matching in `buildRegLookup`
Terzo passaggio opzionale: se fornito `topoKeys[]`, cerca match per token comune tra nome dataset e TopoJSON. Risolve automaticamente `F.-V. GIULIA` → `FRIULI-VENEZIA-GIULIA`.

## Verifica

```bash
npm test      # 57 test JS + 12 Python ✅
npm run build # 29 pagine, 0 errori, 21 link ✅
```
