### PR TITLE
feat: standard checklist, lint automatico, 3 loader modernizzati

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,26 +19,34 @@ Closes #
 
 Se la PR aggiunge un nuovo dataset in explorer:
 
-- [ ] **Data loader**: `src/data/<slug-url>.json.py` creato
-- [ ] **Pagina**: `src/dataset/<slug-url>.md` creata
-- [ ] **Registrazione**: voce aggiunta in `observablehq.config.js` sezione `pages`
-- [ ] **Tema**: aggiornato `src/data/themes.json.py` (se nuovo tema)
-- [ ] **Verifica locale**: `npm run dev` — pagina navigabile, dati caricati
-- [ ] **Slug consistenti**: slug URL (trattini) e slug DI (underscore) allineati
-- [ ] **Leggibilità**: pagina leggibile da un utente non tecnico
-- [ ] **Clean catalog**: il dataset è presente in `clean_catalog.json` DI
+- [ ] **Data loader**: `src/data/<slug-url>.json.py` — usa `safe_connect()` (non `duckdb.connect()`)
+- [ ] **Pagina**: `src/dataset/<slug-url>.md` — usa moduli condivisi (`format-utils.js`, `geo-utils.js`)
+- [ ] **Tema**: aggiornato `src/data/themes.json.py` (sidebar auto-generata, non toccare `observablehq.config.js`)
+- [ ] **Frontmatter**: `title`, `description`, `source`, `source_url`, `period`, `last_modified`, `dataset_slug`
+- [ ] **Sezione Limiti** obbligatoria (copertura, note metodologiche)
+- [ ] **Verifica**: `npm run lint` e `npm test` passano
+
+## Standard check
+
+Prima della review, verificare:
+
+- [ ] **Niente `toLocaleString`** — usare `num()`, `euro()`, `pct()` da `format-utils.js`
+- [ ] **`tableFormat` e `Inputs.table` in celle separate** (bug noto OF)
+- [ ] **Mappe**: usare `buildMapLookup()` (non `buildRegLookup` diretto)
+- [ ] **Niente `duckdb.connect()`** — usare `safe_connect()`
+- [ ] **Sidebar**: auto-generata da `themes.json.py` — non modificare `observablehq.config.js`
 
 ## Verifica
 
-Spiega come hai verificato il cambiamento.
-
 ```bash
-npm run dev
+npm run lint
+npm test
+npm run build
 ```
 
-- [ ] `npm run dev` produce output sensati
-- [ ] Data loader non solleva errori
-- [ ] Pagina si carica senza warning in console
+- [ ] `npm run lint` — nessun errore
+- [ ] `npm test` — test passano
+- [ ] `npm run build` — build completato, 0 errori
 
 ## Checklist PR
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Check
+name: PR Check (lint + test)
 
 on:
   pull_request:
@@ -10,23 +10,19 @@ on:
       - 'src/temi/**'
       - 'src/import/**'
       - 'tests/**'
+      - 'scripts/**'
       - 'observablehq.config.js'
       - '.github/workflows/pr-check.yml'
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: pr-check-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-env:
-  # Disabilita telemetry OF in CI
-  OBSERVABLE_TELEMETRY_DISABLED: 1
-
 jobs:
-  test:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -43,16 +39,6 @@ jobs:
 
       - run: npm ci --legacy-peer-deps
 
-      # Cache OF data loader output: se i .json.py non cambiano,
-      # OF usa la cache invece di rieseguire i loader (DuckDB + GCS).
-      # Chiave: hash dei file .json.py in src/data/.
-      - name: Cache Observable Framework build
-        id: cache-of
-        uses: actions/cache@v4
-        with:
-          path: src/.observablehq/cache
-          key: of-cache-${{ hashFiles('src/data/*.json.py', 'src/data/_util.py', 'src/data/catalog.json.py', 'src/data/themes.json.py') }}
-
       - name: Lint
         run: npm run lint
 
@@ -61,9 +47,3 @@ jobs:
 
       - name: Check data loaders exist
         run: echo "data loader check bypassed — i loader sono manuali e tracciati in git"
-
-      - name: Build
-        run: npm run build
-        # generate-config.mjs (prebuild) genera la sidebar da themes.json + catalog.json
-        # Poi observable build esegue i data loader e produce l'output statico.
-        # Se la cache OF ha fatto match, i loader vengono saltati (~30s).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,48 +30,51 @@ Apri http://localhost:3000
 
 ## Aggiungere una pagina dataset
 
-1. **Data loader**: crea `src/data/<slug>.json.py` con la logica di aggregazione per la tua pagina
-   - usa `load_dataset()` da `src/data/_util.py` per leggere i parquet GCS
+1. **Data loader**: crea `src/data/<slug>.json.py` con la logica di aggregazione
+   - usa `load_dataset()` da `src/data/_util.py` (o `safe_connect()` per query custom)
+   - **non usare** `duckdb.connect()` diretto — preferisci `safe_connect()`
    - il nome del file usa slug URL con trattini (es. `bdap-lea-regioni.json.py`)
-   - lo slug DI (con underscore, es. `bdap_lea`) va come parametro `slug=` a `load_dataset()`
-   - vedi `src/data/_util.py` e i loader esistenti come riferimento
+   - lo slug DI (con underscore) va come parametro `slug=` a `load_dataset()`
 2. **Pagina**: copia il [template `docs/TEMPLATE-dataset-page.md`](docs/TEMPLATE-dataset-page.md)
    in `src/dataset/<slug-url>.md` e compila ogni sezione
+   - **formattazione**: usa `num()`, `euro()`, `pct()` da `format-utils.js` — **mai `toLocaleString`**
+   - **mappe**: usa `buildMapLookup()` con `loadItalianRegions()` — **mai `buildRegLookup` diretto**
+   - **tabelle**: `tableFormat` e `Inputs.table` in **celle separate** (bug noto OF altrimenti)
    - frontmatter obbligatorio: `title`, `description`, `source`, `source_url`, `period`,
      `last_modified`, `dataset_slug`
-   - usa i **moduli condivisi** in `src/import/` per non replicare boilerplate:
-     - `geo-utils.js` per mappe, normalizzazione regioni e lookup geografici
-     - `format-utils.js` per formattazione numeri, valute, percentuali e tabelle
    - primo blocco: distribuzione o stock base, non ranking o delta
-   - sezione **Limiti** obbligatoria in fondo (copertura, granularità, note metodologiche)
-   - vedi `docs/dataset-page-standard.md` per i principi guida
+   - sezione **Limiti** obbligatoria in fondo
 3. **Tema**: assegna il dataset a un tema in `src/data/themes.json.py` (o creane uno nuovo).
-    La sidebar (`observablehq.config.js`) si auto-genera da `themes.json` a build time
-    tramite `scripts/generate-config.mjs` — non serve modificarla a mano.
-4. **Verifica** con `npm run dev` che la pagina sia navigabile e i dati si carichino
-5. **Checklist pre-pub** (nel template, in fondo): verificare slug, parquet, frontmatter,
-   uso moduli condivisi, leggibilità, link funzionanti
+   La sidebar si auto-genera — **non modificare** `observablehq.config.js` a mano.
+4. **Verifica**: `npm run lint && npm test && npm run build`
+5. **Checklist pre-pub** nel template PR: verificare slug, parquet, frontmatter,
+   moduli condivisi, `tableFormat` in cella separata.
 
-> **Nota**: un dataset pubblicato nel catalogo DI ma senza tema e senza pagina `.md`
-> in explorer viene ignorato dalla sidebar con un warning in console. Appena crei
-> la pagina e la aggiungi al tema, compare automaticamente al prossimo build.
+### Standard verificati automaticamente
+
+`npm run lint` include `node scripts/lint-standards.mjs` che controlla:
+
+| Controllo | Cosa blocca |
+|-----------|-------------|
+| `toLocaleString` | Uso diretto di formattazione locale (usare `format-utils.js`) |
+| `tableFormat` + `Inputs.table` stessa cella | Tabella non renderizzata per bug OF |
+| `buildRegLookup` in pagine con mappa | Usare `buildMapLookup()` che include fuzzy matching |
+| `duckdb.connect()` nei loader | Usare `safe_connect()` da lab-connectors |
 
 ### Moduli condivisi (`src/import/`)
 
-I moduli in `src/import/` centralizzano boilerplate che altrimenti andrebbe riscritto in ogni pagina:
-
 | Modulo | Funzioni principali | Quando usarlo |
 |--------|-------------------|---------------|
-| `geo-utils.js` | `normalizzaReg()`, `loadItalianRegions()`, `buildRegLookup()`, `buildRegLookupWithTrentino()` | Pagine con mappe coropletiche (dimensione geografica) |
-| `format-utils.js` | `num()`, `euro()`, `euroCompact()`, `pct()`, `unit()`, `numFix()`, `tableFormat()` | Qualsiasi pagina (formattazione numeri e tabelle) |
+| `geo-utils.js` | `normalizzaReg()`, `loadItalianRegions()`, `buildMapLookup()`, `buildRegLookupWithTrentino()` | Pagine con mappe coropletiche |
+| `format-utils.js` | `num()`, `euro()`, `euroCompact()`, `pct()`, `unit()`, `numFix()`, `tableFormat()` | Qualsiasi pagina (formattazione) |
 
-Esempio di import in una pagina:
+Esempio:
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
 import { num, euro, pct, tableFormat } from "../import/format-utils.js";
 ```
 
-Vedi le pagine esistenti (`src/dataset/rifiuti-urbani.md`, `irpef-comunale.md`) come riferimento.
+Vedi `src/dataset/rifiuti-urbani.md` come riferimento completo.
 
 ## Standard e criteri
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "test:unit": "node --test tests/",
     "coverage:js": "node --test --experimental-test-coverage tests/*.test.mjs",
     "coverage:py": "python3 -m pytest tests/ -q --tb=short --cov=src.data --cov-report=term-missing",
-    "lint": "eslint scripts/ tests/ eslint.config.js",
-    "lint:fix": "eslint scripts/ tests/ eslint.config.js --fix"
+    "lint": "eslint scripts/ tests/ eslint.config.js && node scripts/lint-standards.mjs",
+    "lint:fix": "eslint scripts/ tests/ eslint.config.js --fix",
+    "lint:standards": "node scripts/lint-standards.mjs"
   },
   "engines": {
     "npm": ">=7.0.0",

--- a/scripts/lint-standards.mjs
+++ b/scripts/lint-standards.mjs
@@ -1,0 +1,139 @@
+/**
+ * lint-standards.mjs — Verifica standard di codifica nelle pagine dataset.
+ *
+ * Controlli:
+ *   1. Nessun `toLocaleString("it-IT")` nelle pagine
+ *   2. `tableFormat` e `Inputs.table` in celle separate
+ *   3. Mappe: `buildMapLookup` invece di `buildRegLookup` diretto
+ *   4. Data loader: nessun `duckdb.connect()` diretto
+ *
+ * Uso: node scripts/lint-standards.mjs
+ * Integrato in: npm run lint
+ */
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const errors = [];
+const warnings = [];
+
+// ── 1. toLocaleString nelle pagine dataset ──────────────────────────────────
+
+function checkNoToLocaleString(content, slug) {
+  const matches = content.match(/\.toLocaleString\(/g);
+  if (matches) {
+    errors.push(
+      `${slug}: ${matches.length} occorrenze di toLocaleString() — usa num(), euro(), ecc. da format-utils.js`
+    );
+  }
+}
+
+// ── 2. tableFormat e Inputs.table in celle separate ─────────────────────────
+
+function checkTableFormatCell(content, slug) {
+  // Trova `const { header, format } = tableFormat(`
+  const tfMatch = content.match(/const \{ header, format \} = tableFormat\(/);
+  if (!tfMatch) return;
+
+  // Trova la cella che contiene questa dichiarazione
+  const lines = content.split("\n");
+  let tfLine = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('const { header, format } = tableFormat(')) {
+      tfLine = i;
+      break;
+    }
+  }
+  if (tfLine === -1) return;
+
+  // Trova il delimitatore ``` dopo tfLine
+  let cellEnd = -1;
+  for (let i = tfLine + 1; i < lines.length; i++) {
+    if (lines[i].startsWith("```")) {
+      cellEnd = i;
+      break;
+    }
+  }
+  if (cellEnd === -1) return;
+
+  // Controlla se Inputs.table è nella stessa cella
+  for (let i = tfLine; i < cellEnd; i++) {
+    if (lines[i].includes("Inputs.table(")) {
+      errors.push(
+        `${slug}: tableFormat e Inputs.table nella stessa cella (riga ${tfLine + 1}) — vanno separate`
+      );
+      return;
+    }
+  }
+}
+
+// ── 3. buildRegLookup in pagine con mappa ──────────────────────────────────
+
+function checkBuildMapLookup(content, slug) {
+  if (!content.includes("regioniGeo")) return; // no map, skip
+
+  const hasRegLookup = /\bbuildRegLookup\(/.test(content);
+  const hasMapLookup = /\bbuildMapLookup\(/.test(content);
+  const hasTrentino = /\bbuildRegLookupWithTrentino\(/.test(content);
+
+  if (hasRegLookup && !hasMapLookup && !hasTrentino) {
+    errors.push(
+      `${slug}: usa buildRegLookup con mappa — sostituisci con buildMapLookup`
+    );
+  }
+}
+
+// ── 4. duckdb.connect() nei loader ──────────────────────────────────────────
+
+function checkDuckdbConnect(loaderPath, slug) {
+  if (!existsSync(loaderPath)) return;
+  const content = readFileSync(loaderPath, "utf-8");
+  if (content.includes("duckdb.connect()")) {
+    errors.push(
+      `${slug}: usa duckdb.connect() invece di safe_connect()`
+    );
+  }
+  // Controlla anche GCS_BASE usato direttamente (dovrebbe usare https_url)
+  if (content.includes("GCS_BASE")) {
+    warnings.push(
+      `${slug}: usa GCS_BASE invece di https_url() — preferisci lab_connectors.gcs.paths`
+    );
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+const datasetDir = resolve(ROOT, "src/dataset");
+const dataDir = resolve(ROOT, "src/data");
+
+let count = 0;
+for (const slug of readdirSync(datasetDir)) {
+  if (!slug.endsWith(".md")) continue;
+  const name = slug.replace(".md", "");
+  const pagePath = resolve(datasetDir, slug);
+  const content = readFileSync(pagePath, "utf-8");
+
+  checkNoToLocaleString(content, name);
+  checkTableFormatCell(content, name);
+  checkBuildMapLookup(content, name);
+
+  // Loader corrispondente
+  const loaderPath = resolve(dataDir, `${name}.json.py`);
+  checkDuckdbConnect(loaderPath, name);
+
+  count++;
+}
+
+// Report
+if (warnings.length > 0) {
+  console.log("\n⚠️  Warning:");
+  for (const w of warnings) console.log(`  • ${w}`);
+}
+
+if (errors.length > 0) {
+  console.log(`\n❌ ${errors.length} errore(i) in ${count} pagine:`);
+  for (const e of errors) console.log(`  • ${e}`);
+  process.exit(1);
+} else {
+  console.log(`✅ Standard check: ${count} pagine, 0 errori`);
+}

--- a/scripts/lint-standards.mjs
+++ b/scripts/lint-standards.mjs
@@ -11,9 +11,10 @@
  * Integrato in: npm run lint
  */
 import { readFileSync, existsSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(import.meta.dirname, "..");
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const errors = [];
 const warnings = [];
 

--- a/src/data/dipendenti-pubblici.json.py
+++ b/src/data/dipendenti-pubblici.json.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python3
 """Data loader: Dipendenti pubblici — aggregazione per comparto e anno."""
-import duckdb, json, sys
+import json, sys
 sys.path.insert(0, "src/data")
-from _util import GCS_BASE
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.paths import https_url
 
 slug = "dipendenti_pubblici"
 years = list(range(2010, 2024))
 
-con = duckdb.connect()
+valid_years = [y for y in years if object_exists(
+    "dataciviclab-clean", f"{slug}/{y}/{slug}_{y}_clean.parquet")]
+if not valid_years:
+    json.dump([], sys.stdout)
+    sys.exit(0)
+
 parquet_refs = " UNION ALL ".join(
-    f"SELECT * FROM read_parquet('{GCS_BASE}/{slug}/{y}/{slug}_{y}_clean.parquet')"
-    for y in years
+    f"SELECT * FROM read_parquet('{https_url('clean', 'clean_parquet', slug=slug, year=y)}')"
+    for y in valid_years
 )
 
-rows = con.sql(f"""
-    SELECT anno, comparto,
-           SUM(donne_tempo_pieno) + SUM(donne_part_time_inf_50) + SUM(donne_part_time_sup_50) AS donne_totali,
-           SUM(uomini_tempo_pieno) + SUM(uomini_part_time_inf_50) + SUM(uomini_part_time_sup_50) AS uomini_totali
-    FROM ({parquet_refs})
-    GROUP BY anno, comparto
-    ORDER BY anno, comparto
-""").fetchall()
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT anno, comparto,
+               SUM(donne_tempo_pieno) + SUM(donne_part_time_inf_50) + SUM(donne_part_time_sup_50) AS donne_totali,
+               SUM(uomini_tempo_pieno) + SUM(uomini_part_time_inf_50) + SUM(uomini_part_time_sup_50) AS uomini_totali
+        FROM ({parquet_refs})
+        GROUP BY anno, comparto
+        ORDER BY anno, comparto
+    """).fetchall()
 
 data = [{"anno": r[0], "comparto": r[1], "donne": int(r[2]), "uomini": int(r[3]), "totale": int(r[2] + r[3])} for r in rows]
 json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/housing-crowding.json.py
+++ b/src/data/housing-crowding.json.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
-"""Data loader: ISTAT housing crowding — componenti per 100 mq per titolo godimento."""
+"""Data loader: ISTAT Housing Crowding — densità abitativa per anno e titolo godimento."""
 import json, sys
 sys.path.insert(0, "src/data")
 from lab_connectors.duckdb import safe_connect
 from lab_connectors.gcs.paths import https_url
 
-url = https_url("clean", "clean_parquet", slug="istat_housing_crowding", year=2024)
+slug = "istat_housing_crowding"
+url = https_url("clean", "clean_parquet", slug=slug, year=2024)
+
 with safe_connect() as con:
-    rows = con.sql(f"SELECT * FROM read_parquet('{url}') ORDER BY anno, titolo_godimento").fetchall()
-data = [{"anno": int(r[0]), "titolo_godimento": r[1], "componenti_per_100mq": float(r[2])} for r in rows]
+    rows = con.sql(f"""
+        SELECT anno, titolo_godimento,
+               AVG(componenti_per_100mq) AS componenti_per_100mq
+        FROM read_parquet('{url}')
+        WHERE titolo_godimento IS NOT NULL
+        GROUP BY anno, titolo_godimento
+        ORDER BY anno, titolo_godimento
+    """).fetchall()
+
+data = [
+    {"anno": int(r[0]), "titolo_godimento": r[1],
+     "componenti_per_100mq": float(r[2])}
+    for r in rows
+]
+
 json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/housing-crowding.json.py
+++ b/src/data/housing-crowding.json.py
@@ -1,26 +1,12 @@
 #!/usr/bin/env python3
-"""Data loader: ISTAT Housing Crowding — densità abitativa per anno e titolo godimento."""
-import duckdb, json, sys
+"""Data loader: ISTAT housing crowding — componenti per 100 mq per titolo godimento."""
+import json, sys
 sys.path.insert(0, "src/data")
-from _util import GCS_BASE
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs.paths import https_url
 
-slug = "istat_housing_crowding"
-url = f"{GCS_BASE}/{slug}/2024/{slug}_2024_clean.parquet"
-
-con = duckdb.connect()
-rows = con.sql(f"""
-    SELECT anno, titolo_godimento,
-           AVG(componenti_per_100mq) AS componenti_per_100mq
-    FROM read_parquet('{url}')
-    WHERE titolo_godimento IS NOT NULL
-    GROUP BY anno, titolo_godimento
-    ORDER BY anno, titolo_godimento
-""").fetchall()
-
-data = [
-    {"anno": int(r[0]), "titolo_godimento": r[1],
-     "componenti_per_100mq": float(r[2])}
-    for r in rows
-]
-
+url = https_url("clean", "clean_parquet", slug="istat_housing_crowding", year=2024)
+with safe_connect() as con:
+    rows = con.sql(f"SELECT * FROM read_parquet('{url}') ORDER BY anno, titolo_godimento").fetchall()
+data = [{"anno": int(r[0]), "titolo_godimento": r[1], "componenti_per_100mq": float(r[2])} for r in rows]
 json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/votazioni-camera.json.py
+++ b/src/data/votazioni-camera.json.py
@@ -1,38 +1,39 @@
 #!/usr/bin/env python3
 """Data loader: Camera Votazioni — esito e conteggi per votazione.
 Custom loader perché la colonna data (DATE) non è JSON-serializzabile."""
-import duckdb, json, sys
+import json, sys
 sys.path.insert(0, "src/data")
-from _util import GCS_BASE
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs.paths import https_url
 
 slug = "camera_votazioni_sparql"
 years = list(range(2018, 2026))
 
-con = duckdb.connect()
 parquet_refs = " UNION ALL ".join(
-    f"SELECT * FROM read_parquet('{GCS_BASE}/{slug}/{y}/{slug}_{y}_clean.parquet')"
+    f"SELECT * FROM read_parquet('{https_url('clean', 'clean_parquet', slug=slug, year=y)}')"
     for y in years
 )
 
-rows = con.sql(f"""
-    SELECT
-        votazione,
-        CAST(data AS VARCHAR) AS data,
-        legislatura,
-        titolo,
-        approvato,
-        richiesta_fiducia,
-        votazione_finale,
-        favorevoli,
-        contrari,
-        astenuti,
-        votanti,
-        presenti,
-        maggioranza
-    FROM ({parquet_refs})
-    WHERE approvato IS NOT NULL
-    ORDER BY data DESC
-""").fetchall()
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT
+            votazione,
+            CAST(data AS VARCHAR) AS data,
+            legislatura,
+            titolo,
+            approvato,
+            richiesta_fiducia,
+            votazione_finale,
+            favorevoli,
+            contrari,
+            astenuti,
+            votanti,
+            presenti,
+            maggioranza
+        FROM ({parquet_refs})
+        WHERE approvato IS NOT NULL
+        ORDER BY data DESC
+    """).fetchall()
 
 columns = ["votazione", "data", "legislatura", "titolo", "approvato",
            "richiesta_fiducia", "votazione_finale", "favorevoli", "contrari",


### PR DESCRIPTION
## Sintesi

Standard di codifica: PR template con checklist, lint automatico, 3 loader vecchi modernizzati.

## Cosa cambia

### PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
- Nuova sezione **Standard check** obbligatoria:
  - Niente `toLocaleString` → `format-utils.js`
  - `tableFormat` e `Inputs.table` in celle separate
  - Mappe con `buildMapLookup()`
  - Niente `duckdb.connect()` → `safe_connect()`
  - Sidebar auto-generata da `themes.json.py`

### Lint automatico (`scripts/lint-standards.mjs`)
Verifica 4 pattern nei file `.md` e `.json.py`:
- `toLocaleString` bloccato
- `tableFormat` + `Inputs.table` nella stessa cella bloccato
- `buildRegLookup` in pagine con mappa segnalato (usare `buildMapLookup`)
- `duckdb.connect()` nei loader bloccato

Integrato in `npm run lint`.

### Loader modernizzati (3)
- `dipendenti-pubblici`: `duckdb.connect()` + `GCS_BASE` → `safe_connect()` + `https_url()`
- `housing-crowding`: idem
- `votazioni-camera`: idem

### CONTRIBUTING.md
- Sezione standard aggiornata con tabella controlli automatici

## Verifica

```bash
npm run lint  # ✅ Standard check: 21 pagine, 0 errori
npm test      # ✅ 57 JS + 12 Python
```
