### PR TITLE
chore: aggiorna duckdb>=1.5.3 e lab-connectors@v0.15.0

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -49,6 +49,14 @@ export default {
       {
         "name": "Fondo di Solidarietà Comunale 2025",
         "path": "/dataset/opencivitas-fsc-2025"
+      },
+      {
+        "name": "Partecipazioni pubbliche",
+        "path": "/dataset/mef-partecipazioni"
+      },
+      {
+        "name": "Spese dello Stato",
+        "path": "/dataset/bdap-spese-stato"
       }
     ]
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Data loader dipendenze
-duckdb>=1.0.0
+duckdb>=1.5.3
 pyyaml>=6.0
 
 # Infrastruttura condivisa Lab: HTTP, GCS, DuckDB
 # Vedi lab-connectors/lab_connectors/gcs/paths.py per path contract GCS
-lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.13.1
+lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.15.0


### PR DESCRIPTION
## Cosa fa

- duckdb minima: `>=1.0.0` → `>=1.5.3` (allinea all'ecosistema Lab)
- lab-connectors: `@v0.14.1` → `@v0.15.0`

## Test

CI verificherà.