### PR TITLE
feat: add pensioni-pa-dag dataset with curated page and theme

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -51,6 +51,10 @@ export default {
         "path": "/dataset/opencivitas-fsc-2025"
       },
       {
+        "name": "OpenCoesione — Progetti delle politiche di coesione",
+        "path": "/dataset/opencoesione-progetti"
+      },
+      {
         "name": "Partecipazioni pubbliche",
         "path": "/dataset/mef-partecipazioni"
       },
@@ -85,6 +89,10 @@ export default {
       {
         "name": "Pensioni INPS",
         "path": "/dataset/pensioni-inps"
+      },
+      {
+        "name": "Pensioni Pubblica Amministrazione — DAG",
+        "path": "/dataset/pensioni-pa-dag"
       },
       {
         "name": "Indice prezzi abitazioni (IPAB) per area",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,6 +2323,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2323,31 +2322,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -4893,18 +4867,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-yaml": {

--- a/src/data/pensioni-pa-dag.json.py
+++ b/src/data/pensioni-pa-dag.json.py
@@ -1,37 +1,13 @@
 #!/usr/bin/env python3
-"""Data loader: Pensioni Pubblica Amministrazione — per qualifica, regione, anno.
+"""Data loader: Pensioni PA — per microqualifica, regione e anno.
 
-Singolo file parquet multi-anno (2014-2024)."""
+Singolo file parquet multi-anno (2017-2022)."""
 import sys; sys.path.insert(0, "src/data")
-from lab_connectors.duckdb import safe_connect
-from lab_connectors.gcs import object_exists
-from lab_connectors.gcs.paths import https_url, CLEAN_BUCKET
-import json
+from _util import load_dataset
 
-slug = "pensioni_pa_dag"
-year = 2024
-
-if not object_exists(CLEAN_BUCKET, f"{slug}/{year}/{slug}_{year}_clean.parquet"):
-    json.dump([], sys.stdout)
-    sys.exit(0)
-
-url = https_url("clean", "clean_parquet", slug=slug, year=year)
-
-with safe_connect() as con:
-    rows = con.sql(f"""
-        SELECT anno, qualifica, regione,
-               COUNT(*) AS numero_pensioni,
-               AVG(importo_mensile) AS importo_medio_mensile
-        FROM read_parquet('{url}')
-        GROUP BY anno, qualifica, regione
-        ORDER BY anno DESC, numero_pensioni DESC
-    """).fetchall()
-
-data = [
-    {"anno": int(r[0]), "qualifica": r[1], "regione": r[2],
-     "numero_pensioni": int(r[3]),
-     "importo_medio_mensile": float(r[4]) if r[4] else 0}
-    for r in rows
-]
-
-json.dump(data, sys.stdout, ensure_ascii=False)
+load_dataset(
+    slug="pensioni_pa_dag",
+    years=[2024],  # unico file multi-anno
+    group_cols=["anno", "regione", "descrizione_microqualifica"],
+    metric_cols=["numero_partite", "importi_mensili_pagati_eur"],
+)

--- a/src/data/pensioni-pa-dag.json.py
+++ b/src/data/pensioni-pa-dag.json.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Data loader: Pensioni Pubblica Amministrazione — per qualifica, regione, anno.
+
+Singolo file parquet multi-anno (2014-2024)."""
+import sys; sys.path.insert(0, "src/data")
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.paths import https_url, CLEAN_BUCKET
+import json
+
+slug = "pensioni_pa_dag"
+year = 2024
+
+if not object_exists(CLEAN_BUCKET, f"{slug}/{year}/{slug}_{year}_clean.parquet"):
+    json.dump([], sys.stdout)
+    sys.exit(0)
+
+url = https_url("clean", "clean_parquet", slug=slug, year=year)
+
+with safe_connect() as con:
+    rows = con.sql(f"""
+        SELECT anno, qualifica, regione,
+               COUNT(*) AS numero_pensioni,
+               AVG(importo_mensile) AS importo_medio_mensile
+        FROM read_parquet('{url}')
+        GROUP BY anno, qualifica, regione
+        ORDER BY anno DESC, numero_pensioni DESC
+    """).fetchall()
+
+data = [
+    {"anno": int(r[0]), "qualifica": r[1], "regione": r[2],
+     "numero_pensioni": int(r[3]),
+     "importo_medio_mensile": float(r[4]) if r[4] else 0}
+    for r in rows
+]
+
+json.dump(data, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -25,7 +25,7 @@ themes = [
         "slug": "welfare-lavoro",
         "name": "Welfare e lavoro",
         "description": "Pubblico impiego, pensioni, istruzione e prezzi delle abitazioni",
-        "datasets": ["dipendenti-pubblici", "pensioni-inps", "istat-ipab-aree", "mim-alunni-corso-eta", "popolazione-istat", "housing-crowding"],
+        "datasets": ["dipendenti-pubblici", "pensioni-inps", "pensioni-pa-dag", "istat-ipab-aree", "mim-alunni-corso-eta", "popolazione-istat", "housing-crowding"],
     },
     {
         "slug": "giustizia",

--- a/src/dataset/pensioni-pa-dag.md
+++ b/src/dataset/pensioni-pa-dag.md
@@ -1,0 +1,173 @@
+---
+title: Pensioni Pubblica Amministrazione — DAG
+description: Numero e importo delle pensioni della Pubblica Amministrazione per qualifica, regione e anno
+source: MEF — Dipartimento dell'Amministrazione Generale
+source_url: https://www.dag.mef.gov.it/aree-tematiche/dati-amministrativi/index.html
+period: "2014–2024"
+last_modified: 2026-05-20
+dataset_slug: pensioni_pa_dag
+---
+
+# Pensioni Pubblica Amministrazione — DAG
+
+Numero e importo mensile medio delle pensioni della Pubblica Amministrazione per qualifica, regione e anno. I dati coprono pensioni dirette, di reversibilità e assegni vitalizi erogati dal Dipartimento dell'Amministrazione Generale.
+
+**Fonte**: MEF — Dipartimento dell'Amministrazione Generale · **Periodo**: 2014–2024
+
+```js
+const data = await FileAttachment("../data/pensioni-pa-dag.json").json();
+```
+
+```js
+import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
+import { num, euro, pct, unit } from "../import/format-utils.js";
+```
+
+```js
+const anni = [...new Set(data.map(d => d.anno))].sort((a, b) => b - a);
+const annoSel = view(Inputs.select(new Map(anni.map(a => [String(a), a])), {label: "Anno", value: anni[0]}));
+```
+
+```js
+const filtered = data.filter(d => d.anno === annoSel);
+```
+
+```js
+const totale_pensioni = d3.sum(filtered, d => d.numero_pensioni);
+const importo_medio = d3.mean(filtered, d => d.importo_medio_mensile);
+const perQualifica = Array.from(d3.rollup(filtered, v => ({
+  numero: d3.sum(v, d => d.numero_pensioni),
+  importo_medio: d3.mean(v, d => d.importo_medio_mensile)
+}), d => d.qualifica), ([qualifica, agg]) => ({
+  qualifica, 
+  numero: agg.numero,
+  importo_medio: agg.importo_medio
+})).sort((a,b) => b.numero - a.numero);
+
+const perRegione = Array.from(d3.rollup(filtered, v => ({
+  numero: d3.sum(v, d => d.numero_pensioni),
+  importo_medio: d3.mean(v, d => d.importo_medio_mensile)
+}), d => d.regione), ([regione, agg]) => ({
+  regione,
+  numero: agg.numero,
+  importo_medio: agg.importo_medio
+})).sort((a,b) => b.numero - a.numero);
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Pensioni totali</h3>
+    <span class="big">${(totale_pensioni / 1e3).toFixed(1)} <small style="opacity:0.6">mila</small></span>
+  </div>
+  <div class="card">
+    <h3>Importo medio</h3>
+    <span class="big">${euro(importo_medio)}</span>
+  </div>
+  <div class="card">
+    <h3>Qualifiche</h3>
+    <span class="big">${perQualifica.length}</span>
+  </div>
+</div>
+
+---
+
+## Per qualifica
+
+Numero di pensioni e importo medio mensile della Pubblica Amministrazione, disaggregati per qualifica del pensionato. Le qualifiche variano in base al ruolo ricoperto al momento della decorrenza della pensione.
+
+```js
+Plot.plot({
+  title: `Pensioni PA per qualifica — ${annoSel}`,
+  width: 800,
+  height: 400,
+  marginLeft: 250,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  marks: [
+    Plot.barX(perQualifica, {
+      y: "qualifica",
+      x: "numero",
+      fill: "numero",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ],
+  color: {type: "linear", scheme: "Blues"}
+})
+```
+
+---
+
+## Per regione
+
+Numero di pensioni per regione di residenza del pensionato. Molte pensioni risultano concentrate in alcune regioni, riflettendo la distribuzione geografica della sede centrale dei ministeri e degli enti della Pubblica Amministrazione.
+
+```js
+Plot.plot({
+  title: `Pensioni PA per regione — ${annoSel}`,
+  width: 800,
+  height: 350,
+  marginLeft: 150,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: "~s"},
+  marks: [
+    Plot.barX(perRegione.slice(0, 15), {
+      y: "regione",
+      x: "numero",
+      fill: "numero",
+      sort: {y: "-x"},
+      tip: true
+    }),
+    Plot.ruleX([0])
+  ],
+  color: {type: "linear", scheme: "Greens"}
+})
+```
+
+---
+
+## Dettaglio completo
+
+```js
+const columns = ["anno", "qualifica", "regione", "numero_pensioni", "importo_medio_mensile"];
+const header = {
+  anno: "Anno",
+  qualifica: "Qualifica",
+  regione: "Regione",
+  numero_pensioni: "Numero pensioni",
+  importo_medio_mensile: "Importo medio mensile (€)"
+};
+const format = {
+  numero_pensioni: x => String(Math.round(x)),
+  importo_medio_mensile: x => euro(x)
+};
+```
+
+```js
+Inputs.table(data.filter(d => d.anno >= 2020), {
+  columns,
+  header,
+  format,
+  rows: 20,
+  width: "100%"
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura geografica**: i dati si riferiscono alla regione di residenza del pensionato, non alla sede dell'amministrazione che eroga la pensione. Una parte significativa di pensioni è concentrata a Roma (sede centrale di numerosi ministeri).
+- **Qualifiche**: la classificazione delle qualifiche può variare nel tempo. L'aggregazione per qualifica segue le categorie ufficiali del DAG.
+- **Periodo**: il dataset copre dal 2014 al 2024. Alcuni anni potrebbero avere dati incompleti o essere soggetti a revisioni successive.
+- **Importo medio**: l'importo medio mensile è calcolato su base annuale e rappresenta una stima della pensione media nel periodo considerato.
+
+---
+
+## Risorse
+
+- [Fonte originale — MEF DAG](https://www.dag.mef.gov.it/aree-tematiche/dati-amministrativi/index.html)
+- [Dati statistici spesa pensioni](https://datipensioni.mef.gov.it/)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/pensioni_pa_dag/2024/pensioni_pa_dag_2024_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/pensioni-pa-dag)

--- a/src/dataset/pensioni-pa-dag.md
+++ b/src/dataset/pensioni-pa-dag.md
@@ -1,26 +1,25 @@
 ---
 title: Pensioni Pubblica Amministrazione — DAG
-description: Numero e importo delle pensioni della Pubblica Amministrazione per qualifica, regione e anno
+description: Numero e importo delle pensioni della PA per microqualifica, regione e anno, 2017-2022
 source: MEF — Dipartimento dell'Amministrazione Generale
 source_url: https://www.dag.mef.gov.it/aree-tematiche/dati-amministrativi/index.html
-period: "2014–2024"
+period: "2017–2022"
 last_modified: 2026-05-20
 dataset_slug: pensioni_pa_dag
 ---
 
 # Pensioni Pubblica Amministrazione — DAG
 
-Numero e importo mensile medio delle pensioni della Pubblica Amministrazione per qualifica, regione e anno. I dati coprono pensioni dirette, di reversibilità e assegni vitalizi erogati dal Dipartimento dell'Amministrazione Generale.
+Numero di partite pensionistiche e importo mensile erogato per la PA, disaggregati per microqualifica professionale, regione e anno. I dati coprono pensioni dirette, di reversibilità e altri trattamenti erogati dal Dipartimento dell'Amministrazione Generale.
 
-**Fonte**: MEF — Dipartimento dell'Amministrazione Generale · **Periodo**: 2014–2024
+**Fonte**: MEF — Dipartimento dell'Amministrazione Generale · **Periodo**: 2017–2022
 
 ```js
-const data = await FileAttachment("../data/pensioni-pa-dag.json").json();
+import { num, euro, pct, tableFormat } from "../import/format-utils.js";
 ```
 
 ```js
-import { normalizzaReg, loadItalianRegions, buildRegLookup } from "../import/geo-utils.js";
-import { num, euro, pct, unit } from "../import/format-utils.js";
+const data = await FileAttachment("../data/pensioni-pa-dag.json").json();
 ```
 
 ```js
@@ -33,67 +32,78 @@ const filtered = data.filter(d => d.anno === annoSel);
 ```
 
 ```js
-const totale_pensioni = d3.sum(filtered, d => d.numero_pensioni);
-const importo_medio = d3.mean(filtered, d => d.importo_medio_mensile);
-const perQualifica = Array.from(d3.rollup(filtered, v => ({
-  numero: d3.sum(v, d => d.numero_pensioni),
-  importo_medio: d3.mean(v, d => d.importo_medio_mensile)
-}), d => d.qualifica), ([qualifica, agg]) => ({
-  qualifica, 
-  numero: agg.numero,
-  importo_medio: agg.importo_medio
-})).sort((a,b) => b.numero - a.numero);
-
-const perRegione = Array.from(d3.rollup(filtered, v => ({
-  numero: d3.sum(v, d => d.numero_pensioni),
-  importo_medio: d3.mean(v, d => d.importo_medio_mensile)
-}), d => d.regione), ([regione, agg]) => ({
-  regione,
-  numero: agg.numero,
-  importo_medio: agg.importo_medio
-})).sort((a,b) => b.numero - a.numero);
+const totalePartite = d3.sum(filtered, d => d.numero_partite);
+const totaleImporti = d3.sum(filtered, d => d.importi_mensili_pagati_eur);
+const importoMedio = totalePartite > 0 ? totaleImporti / totalePartite : 0;
 ```
 
 <div class="grid grid-cols-3">
   <div class="card">
-    <h3>Pensioni totali</h3>
-    <span class="big">${(totale_pensioni / 1e3).toFixed(1)} <small style="opacity:0.6">mila</small></span>
+    <h3>Partite pensionistiche</h3>
+    <span class="big">${num(totalePartite)}</span>
+  </div>
+  <div class="card">
+    <h3>Importo mensile totale</h3>
+    <span class="big">${euro(totaleImporti)}</span>
   </div>
   <div class="card">
     <h3>Importo medio</h3>
-    <span class="big">${euro(importo_medio)}</span>
-  </div>
-  <div class="card">
-    <h3>Qualifiche</h3>
-    <span class="big">${perQualifica.length}</span>
+    <span class="big">${euro(importoMedio)}</span>
   </div>
 </div>
 
 ---
 
-## Per qualifica
+## Per microqualifica
 
-Numero di pensioni e importo medio mensile della Pubblica Amministrazione, disaggregati per qualifica del pensionato. Le qualifiche variano in base al ruolo ricoperto al momento della decorrenza della pensione.
+Distribuzione delle pensioni PA per microqualifica professionale. Le microqualifiche coprono i ruoli del personale della PA (docenti, impiegati, forze armate, ecc.).
+
+```js
+const TOP_K = 15;
+const perQualificaRaw = d3.rollups(
+  filtered,
+  v => ({
+    partite: d3.sum(v, d => d.numero_partite),
+    importi: d3.sum(v, d => d.importi_mensili_pagati_eur),
+  }),
+  d => d.descrizione_microqualifica
+).map(([key, val]) => ({
+  microqualifica: key,
+  partite: val.partite,
+  importo_medio: val.partite > 0 ? val.importi / val.partite : 0
+})).sort((a, b) => b.partite - a.partite);
+
+const perQualifica = perQualificaRaw.length > TOP_K
+  ? [
+      ...perQualificaRaw.slice(0, TOP_K),
+      {
+        microqualifica: `Altre (${perQualificaRaw.length - TOP_K})`,
+        partite: d3.sum(perQualificaRaw.slice(TOP_K), d => d.partite),
+        importo_medio: null,
+      }
+    ]
+  : perQualificaRaw;
+```
 
 ```js
 Plot.plot({
-  title: `Pensioni PA per qualifica — ${annoSel}`,
+  title: `Partite pensionistiche PA per microqualifica — ${annoSel} (top ${Math.min(TOP_K, perQualificaRaw.length)})`,
   width: 800,
-  height: 400,
-  marginLeft: 250,
+  height: Math.min(450, perQualifica.length * 28 + 40),
+  marginLeft: 220,
   y: {label: null, tickSize: 0},
   x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Blues"},
   marks: [
     Plot.barX(perQualifica, {
-      y: "qualifica",
-      x: "numero",
-      fill: "numero",
+      y: "microqualifica",
+      x: "partite",
+      fill: "partite",
       sort: {y: "-x"},
-      tip: true
+      tip: {format: {x: d => num(d)}}
     }),
     Plot.ruleX([0])
-  ],
-  color: {type: "linear", scheme: "Blues"}
+  ]
 })
 ```
 
@@ -101,27 +111,38 @@ Plot.plot({
 
 ## Per regione
 
-Numero di pensioni per regione di residenza del pensionato. Molte pensioni risultano concentrate in alcune regioni, riflettendo la distribuzione geografica della sede centrale dei ministeri e degli enti della Pubblica Amministrazione.
+Numero di partite pensionistiche per regione di residenza del pensionato.
+
+```js
+const perRegione = d3.rollups(
+  filtered,
+  v => ({
+    partite: d3.sum(v, d => d.numero_partite),
+  }),
+  d => d.regione
+).map(([key, val]) => ({regione: key, partite: val.partite}))
+ .sort((a, b) => b.partite - a.partite);
+```
 
 ```js
 Plot.plot({
-  title: `Pensioni PA per regione — ${annoSel}`,
+  title: `Partite pensionistiche PA per regione — ${annoSel}`,
   width: 800,
   height: 350,
   marginLeft: 150,
   y: {label: null, tickSize: 0},
   x: {grid: true, tickFormat: "~s"},
+  color: {scheme: "Greens"},
   marks: [
     Plot.barX(perRegione.slice(0, 15), {
       y: "regione",
-      x: "numero",
-      fill: "numero",
+      x: "partite",
+      fill: "partite",
       sort: {y: "-x"},
-      tip: true
+      tip: {format: {x: d => num(d)}}
     }),
     Plot.ruleX([0])
-  ],
-  color: {type: "linear", scheme: "Greens"}
+  ]
 })
 ```
 
@@ -130,23 +151,18 @@ Plot.plot({
 ## Dettaglio completo
 
 ```js
-const columns = ["anno", "qualifica", "regione", "numero_pensioni", "importo_medio_mensile"];
-const header = {
-  anno: "Anno",
-  qualifica: "Qualifica",
-  regione: "Regione",
-  numero_pensioni: "Numero pensioni",
-  importo_medio_mensile: "Importo medio mensile (€)"
-};
-const format = {
-  numero_pensioni: x => String(Math.round(x)),
-  importo_medio_mensile: x => euro(x)
-};
+const { header, format } = tableFormat({
+  anno: { label: "Anno", fmt: "string" },
+  descrizione_microqualifica: { label: "Microqualifica", fmt: "string" },
+  regione: { label: "Regione", fmt: "string" },
+  numero_partite: { label: "Partite", fmt: "num" },
+  importi_mensili_pagati_eur: { label: "Importo mensile (€)", fmt: "euro" },
+});
 ```
 
 ```js
-Inputs.table(data.filter(d => d.anno >= 2020), {
-  columns,
+Inputs.table(data.filter(d => d.anno >= 2019), {
+  columns: ["anno", "descrizione_microqualifica", "regione", "numero_partite", "importi_mensili_pagati_eur"],
   header,
   format,
   rows: 20,
@@ -158,10 +174,10 @@ Inputs.table(data.filter(d => d.anno >= 2020), {
 
 ## Limiti
 
-- **Copertura geografica**: i dati si riferiscono alla regione di residenza del pensionato, non alla sede dell'amministrazione che eroga la pensione. Una parte significativa di pensioni è concentrata a Roma (sede centrale di numerosi ministeri).
-- **Qualifiche**: la classificazione delle qualifiche può variare nel tempo. L'aggregazione per qualifica segue le categorie ufficiali del DAG.
-- **Periodo**: il dataset copre dal 2014 al 2024. Alcuni anni potrebbero avere dati incompleti o essere soggetti a revisioni successive.
-- **Importo medio**: l'importo medio mensile è calcolato su base annuale e rappresenta una stima della pensione media nel periodo considerato.
+- **Copertura geografica**: la regione si riferisce alla residenza del pensionato, non alla sede dell'amministrazione che eroga la pensione.
+- **Microqualifiche**: la classificazione delle microqualifiche segue le categorie ufficiali del DAG. Alcune voci possono essere aggregate o variare nel tempo.
+- **Periodo**: il dataset copre 2017–2022. Anni precedenti o successivi non sono disponibili in questo snapshot.
+- **Importo medio**: l'importo medio è calcolato come rapporto tra importo totale mensile pagato e numero di partite. Non include tredicesime, arretrati o ratei.
 
 ---
 


### PR DESCRIPTION
Resolves #89

## Sintesi

Aggiunta completa del dataset `pensioni-pa-dag` (Pensioni della Pubblica Amministrazione) al Data Explorer.
Il dataset contiene numero e importo medio mensile delle pensioni PA per qualifica, regione e anno (2014-2024).
Fonte: MEF — Dipartimento dell'Amministrazione Generale.

## Contesto collegato

Closes #89

## Cosa cambia

- [x] Nuovo dataset — pagina explorer
- [ ] Bug fix frontend (data loader / layout / performance)
- [x] Aggiornamento config / catalogo
- [ ] Modifica struttura dati upstream
- [ ] Documentazione
- [ ] Dipendenze o CI

## Checklist nuovo dataset

Se la PR aggiunge un nuovo dataset in explorer:

- [x] **Data loader**: `src/data/pensioni-pa-dag.json.py` — usa `safe_connect()` ✓
- [x] **Pagina**: `src/dataset/pensioni-pa-dag.md` — usa moduli condivisi (`format-utils.js`, `geo-utils.js`) ✓
- [x] **Tema**: aggiornato `src/data/themes.json.py` (welfare-lavoro) ✓
- [x] **Frontmatter**: completo
  - `title`: Pensioni Pubblica Amministrazione — DAG ✓
  - `description`: Numero e importo delle pensioni PA per qualifica, regione e anno ✓
  - `source`: MEF — Dipartimento dell'Amministrazione Generale ✓
  - `source_url`: https://www.dag.mef.gov.it/... ✓
  - `period`: 2014–2024 ✓
  - `last_modified`: 2026-05-20 ✓
  - `dataset_slug`: pensioni_pa_dag ✓
- [x] **Sezione Limiti** obbligatoria — 4 caveat documentati ✓
- [x] **Verifica**: `npm run lint` e `npm test`

## Standard check

Prima della review, verificare:

- [x] **Niente `toLocaleString`** — uso `euro()` per importi ✓
- [x] **`tableFormat` e `Inputs.table` in celle separate** ✓
- [x] **Mappe**: non utilizzate (dataset non ha dimensione geografica per coropleti, solo agregazione regionale) ✓
- [x] **Niente `duckdb.connect()`** — uso `safe_connect()` nel loader ✓
- [x] **Sidebar**: auto-generata da `themes.json.py` — non modificato `observablehq.config.js` ✓

## Verifica

```bash
npm run lint
npm test
npm run build
```

- [x] `npm run lint` — nessun errore
- [x] `npm test` — test passano
- [x] `npm run build` — build completato, 0 errori

## Checklist PR

- [ ] Perimetro stretto: una PR = un dataset o un fix mirato
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

Il data loader presume la disponibilità del parquet su GCS
