### PR TITLE
perf: sostituisci object_exists() con gcs_manifest.json in _util.py

### DIFF
--- a/src/data/_util.py
+++ b/src/data/_util.py
@@ -43,18 +43,23 @@ def _load_manifest() -> dict:
 def _parquet_exists(slug: str, year: int) -> bool:
     """Verifica se il parquet esiste su GCS.
 
-    Usa gcs_manifest.json (una GET, lookup in memoria) invece di
-    una HEAD request GCS per ogni slug/year.
-    Fallback a object_exists() se il manifest non è disponibile.
+    Fast path: gcs_manifest.json (una GET, lookup in memoria) —
+    se il manifest contiene il file, esiste sicuro.
+    Slow path (su miss del manifest): object_exists() via HEAD.
+    Il fallback evita falsi negativi quando un parquet è stato
+    pubblicato dopo l'ultimo refresh del manifest (daily).
     """
     manifest = _load_manifest()
     if manifest.get("files"):
         target_path = f"{slug}/{year}/{slug}_{year}_clean.parquet"
-        return any(
+        if any(
             f["bucket"] == CLEAN_BUCKET and f["path"] == target_path
             for f in manifest["files"]
-        )
-    # Fallback: manifest non disponibile, usa HEAD diretto
+        ):
+            return True
+        # Non trovato nel manifest — potrebbe essere stato appena
+        # pubblicato. Cadiamo nel fallback GCS live.
+
     from lab_connectors.gcs import object_exists
 
     return object_exists(

--- a/src/data/_util.py
+++ b/src/data/_util.py
@@ -16,16 +16,47 @@ import json
 import sys
 
 from lab_connectors.duckdb import safe_connect
-from lab_connectors.gcs import object_exists
+from lab_connectors.gcs.manifest import read_manifest
 from lab_connectors.gcs.paths import CLEAN_BUCKET, https_url
 
 # GCS_BASE: backward compat per data loader che lo importano direttamente.
 # Calcolato dal contratto invece che hardcoded.
 GCS_BASE = f"https://storage.googleapis.com/{CLEAN_BUCKET}"
 
+# Cache processo: manifest caricato una volta per loader (ogni loader è
+# un processo Python separato, quindi non serve thread safety).
+_MANIFEST: dict | None = None
+
+
+def _load_manifest() -> dict:
+    """Carica gcs_manifest.json da GCS, con cache di processo."""
+    global _MANIFEST
+    if _MANIFEST is not None:
+        return _MANIFEST
+    try:
+        _MANIFEST = read_manifest()
+    except Exception:
+        _MANIFEST = {"files": []}
+    return _MANIFEST
+
 
 def _parquet_exists(slug: str, year: int) -> bool:
-    """Verifica se il parquet esiste su GCS via object_exists()."""
+    """Verifica se il parquet esiste su GCS.
+
+    Usa gcs_manifest.json (una GET, lookup in memoria) invece di
+    una HEAD request GCS per ogni slug/year.
+    Fallback a object_exists() se il manifest non è disponibile.
+    """
+    manifest = _load_manifest()
+    if manifest.get("files"):
+        target_path = f"{slug}/{year}/{slug}_{year}_clean.parquet"
+        return any(
+            f["bucket"] == CLEAN_BUCKET and f["path"] == target_path
+            for f in manifest["files"]
+        )
+    # Fallback: manifest non disponibile, usa HEAD diretto
+    from lab_connectors.gcs import object_exists
+
     return object_exists(
         CLEAN_BUCKET,
         f"{slug}/{year}/{slug}_{year}_clean.parquet",

--- a/src/data/irpef-capoluoghi.json.py
+++ b/src/data/irpef-capoluoghi.json.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Data loader: IRPEF — capoluoghi di regione (per confronto chart)."""
-import duckdb, json, sys
-sys.path.insert(0, "src/data")
-from _util import GCS_BASE
+import duckdb
+import json
+import sys
+from lab_connectors.gcs.paths import https_url
 
 slug = "irpef_comunale"
 years = list(range(2019, 2024))
@@ -12,7 +13,7 @@ CAPOLUOGHI = ["ROMA", "MILANO", "TORINO", "GENOVA", "NAPOLI", "BOLOGNA", "PALERM
 
 con = duckdb.connect()
 parquet_refs = " UNION ALL ".join(
-    f"SELECT * FROM read_parquet('{GCS_BASE}/{slug}/{y}/{slug}_{y}_clean.parquet')"
+    f"SELECT * FROM read_parquet('{https_url('clean', 'clean_parquet', slug=slug, year=y)}')"
     for y in years
 )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -47,18 +47,32 @@ class TestParquetExists:
 
             assert _parquet_exists("test-slug", 2023) is True
 
-    def test_missing_returns_false_when_not_in_manifest(self):
-        """Path assente dal manifest → non esiste."""
+    def test_missing_returns_false_when_not_in_manifest_and_not_on_gcs(self):
+        """Path assente dal manifest E assente su GCS → non esiste."""
         manifest = _make_manifest(["altro-slug/2023/altro-slug_2023_clean.parquet"])
-        with self._patch_manifest(manifest):
-            from src.data._util import _parquet_exists
+        with patch("lab_connectors.gcs.object_exists", return_value=False):
+            with self._patch_manifest(manifest):
+                from src.data._util import _parquet_exists
 
-            assert _parquet_exists("test-slug", 2023) is False
+                assert _parquet_exists("test-slug", 2023) is False
 
     def test_fallback_to_object_exists_when_manifest_empty(self):
         """Manifest senza files → fallback a object_exists()."""
         with patch("lab_connectors.gcs.object_exists", return_value=True):
             with self._patch_manifest({"files": []}):
+                from src.data._util import _parquet_exists
+
+                assert _parquet_exists("test-slug", 2023) is True
+
+    def test_missing_in_manifest_falls_back_to_gcs(self):
+        """Path non nel manifest ma presente su GCS → esiste (evita falso negativo).
+
+        Un parquet appena pubblicato (dopo l'ultimo refresh del manifest)
+        non deve risultare assente.
+        """
+        manifest = _make_manifest(["altro-slug/2023/altro-slug_2023_clean.parquet"])
+        with patch("lab_connectors.gcs.object_exists", return_value=True):
+            with self._patch_manifest(manifest):
                 from src.data._util import _parquet_exists
 
                 assert _parquet_exists("test-slug", 2023) is True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,8 @@
 Test per _util.py — data loader condiviso per Observable Framework.
 
 Contratto:
-  - _parquet_exists(): verifica esistenza parquet su GCS via object_exists()
+  - _parquet_exists(): verifica esistenza parquet su GCS via gcs_manifest.json
+    con fallback a object_exists() (HEAD) se manifest non disponibile
   - load_dataset(): produce JSON valido su stdout con aggregazioni corrette,
     salta anni senza parquet, gestisce where clause
 
@@ -18,57 +19,61 @@ import pytest
 
 from lab_connectors.gcs.paths import CLEAN_BUCKET
 
-
 # ── _parquet_exists ──────────────────────────────────────────────────────────
 
 
-class TestParquetExists:
-    """Contratto: _parquet_exists usa object_exists() e torna bool."""
+def _make_manifest(paths: list[str]) -> dict:
+    """Crea un manifest finto con i path indicati."""
+    return {
+        "files": [
+            {"bucket": CLEAN_BUCKET, "path": p}
+            for p in paths
+        ]
+    }
 
-    def test_exists_returns_true_on_200(self):
-        """object_exists True → esiste."""
-        with patch("src.data._util.object_exists") as mock_exists:
-            mock_exists.return_value = True
+
+class TestParquetExists:
+    """Contratto: _parquet_exists usa gcs_manifest.json o fallback object_exists."""
+
+    def _patch_manifest(self, manifest: dict):
+        """Patch _load_manifest per restituire un manifest controllato."""
+        return patch("src.data._util._load_manifest", return_value=manifest)
+
+    def test_exists_returns_true_when_in_manifest(self):
+        """Path presente nel manifest → esiste."""
+        manifest = _make_manifest(["test-slug/2023/test-slug_2023_clean.parquet"])
+        with self._patch_manifest(manifest):
             from src.data._util import _parquet_exists
 
-            result = _parquet_exists("test-slug", 2023)
-            assert result is True
-            # Verifica parametri corretti
-            called_bucket, called_key = mock_exists.call_args[0]
-            assert called_bucket == CLEAN_BUCKET
-            assert "test-slug" in called_key
-            assert "2023" in called_key
+            assert _parquet_exists("test-slug", 2023) is True
 
-    def test_missing_returns_false_on_404(self):
-        """object_exists False → non esiste."""
-        with patch("src.data._util.object_exists") as mock_exists:
-            mock_exists.return_value = False
+    def test_missing_returns_false_when_not_in_manifest(self):
+        """Path assente dal manifest → non esiste."""
+        manifest = _make_manifest(["altro-slug/2023/altro-slug_2023_clean.parquet"])
+        with self._patch_manifest(manifest):
             from src.data._util import _parquet_exists
 
             assert _parquet_exists("test-slug", 2023) is False
 
-    def test_passes_correct_bucket_and_key(self):
-        """_parquet_exists chiama object_exists con bucket e key corretti."""
-        with patch("src.data._util.object_exists") as mock_exists:
+    def test_fallback_to_object_exists_when_manifest_empty(self):
+        """Manifest senza files → fallback a object_exists()."""
+        with patch("lab_connectors.gcs.object_exists", return_value=True):
+            with self._patch_manifest({"files": []}):
+                from src.data._util import _parquet_exists
+
+                assert _parquet_exists("test-slug", 2023) is True
+
+    def test_fallback_passes_correct_params(self):
+        """Fallback chiama object_exists con bucket e key corretti."""
+        with patch("lab_connectors.gcs.object_exists") as mock_exists:
             mock_exists.return_value = True
-            from src.data._util import _parquet_exists
+            with self._patch_manifest({}):
+                from src.data._util import _parquet_exists
 
-            _parquet_exists("test-slug", 2023)
-            called_bucket, called_key = mock_exists.call_args[0]
-            assert called_bucket == CLEAN_BUCKET
-            assert called_key == "test-slug/2023/test-slug_2023_clean.parquet"
-
-    def test_url_uses_path_contract(self):
-        """Key passata a object_exists segue il path contract."""
-        with patch("src.data._util.object_exists") as mock_exists:
-            mock_exists.return_value = True
-            from src.data._util import _parquet_exists
-
-            _parquet_exists("mio-slug", 2024)
-            called_key = mock_exists.call_args[0][1]
-            assert "mio-slug" in called_key
-            assert "2024" in called_key
-            assert "clean.parquet" in called_key
+                _parquet_exists("test-slug", 2023)
+                called_bucket, called_key = mock_exists.call_args[0]
+                assert called_bucket == CLEAN_BUCKET
+                assert called_key == "test-slug/2023/test-slug_2023_clean.parquet"
 
 
 # ── load_dataset ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Sintesi

Sostituisce le HEAD request GCS (`object_exists()`) con lookup su `gcs_manifest.json` per verificare se un parquet esiste prima di processarlo.

## Cosa cambia

- **`_util.py`**: `_parquet_exists()` ora carica `gcs_manifest.json` (una GET) e fa lookup in memoria, invece di una HEAD per ogni slug/year
- Cache di processo: il manifest è caricato una volta per data loader
- Fallback: se il manifest non è disponibile, ripiega su `object_exists()` (nessuna regressione)

## Impatto

Prima: ogni loader faceva N HEAD request GCS (una per anno, ~150ms cad.).
Con 25 loader × ~5 anni = ~125 HEAD = **~19 secondi spesi solo in check**.

Dopo: una GET del manifest (~150ms, cacheata) + lookup in memoria (~0ms).
Il manifest è aggiornato giornalmente da GHA (`gcs-manifest.yml` in lab-connectors).

## Verifica

```bash
python3 src/data/farmacie.json.py      # OK, dati reali
python3 src/data/irpef-regioni.json.py # OK, dati reali
ruff check src/data/_util.py            # passed
```

- [x] Test manuale su 2 loader (farmacie, irpef-regioni)
- [x] `ruff check` passa
