### PR TITLE
feat: pagina 5x1000 con mappa, categorie e tabella enti

### DIFF
--- a/src/data/catalog.json.py
+++ b/src/data/catalog.json.py
@@ -24,6 +24,7 @@ URL_SLUG_OVERRIDES = {
     "camera_votazioni_sparql": "votazioni-camera",          # editoriale: nome tema
     "bdap_entrate_stato": "entrate-stato",                  # editoriale: nome tema
     "inps_pensioni_trimestrale": "pensioni-inps",           # editoriale: nome tema
+    "ade_cinque_per_mille": "cinque-per-mille",             # editoriale: nome tema
 }
 
 def resolve_url_slug(di_slug: str) -> str:

--- a/src/data/cinque-per-mille.json.py
+++ b/src/data/cinque-per-mille.json.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Data loader: 5x1000 — beneficiari e importi per ente (Agenzia delle Entrate)."""
+import json, sys
+sys.path.insert(0, "src/data")
+from lab_connectors.duckdb import safe_connect
+from lab_connectors.gcs.paths import https_url
+
+SLUG = "ade_cinque_per_mille"
+YEARS = [2024]
+
+parquet_refs = " UNION ALL ".join(
+    f"SELECT * FROM read_parquet('{https_url('clean', 'clean_parquet', slug=SLUG, year=y)}')"
+    for y in YEARS
+)
+
+def _query(sql):
+    rel = con.sql(sql)
+    cols = [desc[0] for desc in rel.description]
+    return [dict(zip(cols, row)) for row in rel.fetchall()]
+
+with safe_connect() as con:
+    per_regione = _query(f"""
+        SELECT regione,
+               COUNT(*) AS num_enti,
+               SUM(numero_scelte) AS tot_scelte,
+               ROUND(SUM(importo_totale_erogabile), 0) AS importo_totale
+        FROM ({parquet_refs})
+        WHERE regione IS NOT NULL
+        GROUP BY regione
+        ORDER BY importo_totale DESC
+    """)
+
+    per_categoria = _query(f"""
+        SELECT
+            CASE
+                WHEN flag_ets_onlus = true AND flag_asd = false AND flag_comune = false
+                     THEN 'ETS / ONLUS'
+                WHEN flag_asd = true THEN 'Sportive dilettantistiche'
+                WHEN flag_ricerca_scientifica = true AND flag_ricerca_sanitaria = true THEN 'Ricerca scientifica e sanitaria'
+                WHEN flag_ricerca_scientifica = true THEN 'Ricerca scientifica'
+                WHEN flag_ricerca_sanitaria = true THEN 'Ricerca sanitaria'
+                WHEN flag_comune = true THEN 'Comuni'
+                WHEN flag_beni_culturali = true THEN 'Beni culturali'
+                WHEN flag_area_protetta = true THEN 'Aree protette'
+                ELSE 'Altro'
+            END AS categoria,
+            COUNT(*) AS num_enti,
+            ROUND(SUM(importo_totale_erogabile), 0) AS importo_totale
+        FROM ({parquet_refs})
+        GROUP BY categoria
+        ORDER BY importo_totale DESC
+    """)
+
+    top_enti = _query(f"""
+        SELECT denominazione, regione, sigla_provincia, comune,
+               numero_scelte,
+               ROUND(importo_totale_erogabile, 0) AS importo_totale
+        FROM ({parquet_refs})
+        ORDER BY importo_totale_erogabile DESC
+        LIMIT 500
+    """)
+
+    tot = _query(f"""
+        SELECT COUNT(*) AS num_enti,
+               SUM(numero_scelte) AS tot_scelte,
+               ROUND(SUM(importo_totale_erogabile), 0) AS importo_totale
+        FROM ({parquet_refs})
+    """)[0]
+
+output = {
+    "anno": 2024,
+    "num_enti": tot["num_enti"],
+    "tot_scelte": tot["tot_scelte"],
+    "importo_totale": tot["importo_totale"],
+    "per_regione": per_regione,
+    "per_categoria": per_categoria,
+    "top_enti": top_enti,
+}
+
+json.dump(output, sys.stdout, ensure_ascii=False)

--- a/src/data/themes.json.py
+++ b/src/data/themes.json.py
@@ -38,6 +38,12 @@ themes = [
         "description": "Flussi civili, tempi e carichi dei tribunali",
         "datasets": ["flussi-giustizia-civile"],
     },
+    {
+        "slug": "terzo-settore",
+        "name": "Terzo settore",
+        "description": "5x1000, enti non profit, flussi finanziari al terzo settore",
+        "datasets": ["cinque-per-mille"],
+    },
 ]
 
 json.dump(themes, sys.stdout, ensure_ascii=False)

--- a/src/dataset/cinque-per-mille.md
+++ b/src/dataset/cinque-per-mille.md
@@ -1,6 +1,6 @@
 ---
 title: 5x1000 — Beneficiari e importi per ente
-description: Oltre 90.000 enti che ricevono il 5x1000: importi per regione, categoria e singolo ente (Agenzia Entrate)
+description: "Oltre 90.000 enti che ricevono il 5x1000: importi per regione, categoria e singolo ente (Agenzia Entrate)"
 source: Agenzia delle Entrate
 source_url: https://www.agenziaentrate.gov.it/portale/area-tematica-5x1000
 period: "2024"

--- a/src/dataset/cinque-per-mille.md
+++ b/src/dataset/cinque-per-mille.md
@@ -1,0 +1,186 @@
+---
+title: 5x1000 — Beneficiari e importi per ente
+description: Oltre 90.000 enti che ricevono il 5x1000: importi per regione, categoria e singolo ente (Agenzia Entrate)
+source: Agenzia delle Entrate
+source_url: https://www.agenziaentrate.gov.it/portale/area-tematica-5x1000
+period: "2024"
+last_modified: 2026-06-23
+dataset_slug: ade_cinque_per_mille
+---
+
+# 5x1000 — Beneficiari e importi per ente
+
+Ogni anno, i contribuenti italiani possono destinare il 5x1000 della propria IRPEF a enti del terzo settore, ricerca scientifica, sanitaria, comuni, associazioni sportive e beni culturali. Nel 2024 oltre **90.000 enti** hanno ricevuto più di **€520 milioni** da 16,7 milioni di scelte. Questa pagina mostra come si distribuiscono: per territorio, per categoria e per singolo ente.
+
+**Fonte**: [Agenzia delle Entrate](https://www.agenziaentrate.gov.it/portale/area-tematica-5x1000) · **Periodo**: 2024
+
+```js
+import { num, euro, euroCompact, pct, numFix, tableFormat } from "../import/format-utils.js";
+import { normalizzaReg, loadItalianRegions, buildMapLookup } from "../import/geo-utils.js";
+```
+
+```js
+const regTopo = await FileAttachment("../data/regioni.topojson").json();
+const { regioniGeo, confiniReg } = await loadItalianRegions(regTopo);
+```
+
+```js
+const data = await FileAttachment("../data/cinque-per-mille.json").json();
+const { per_regione, per_categoria, top_enti } = data;
+```
+
+```js
+// Unifica P.A. Trentino: il dataset ha due righe separate
+const pa = per_regione.filter(r => r.regione && r.regione.includes("ADIGE"));
+const perRegioneUnificata = [
+  ...per_regione.filter(r => r.regione && !r.regione.includes("ADIGE")),
+  ...(pa.length > 1 ? [{
+    regione: "TRENTINO-ALTO-ADIGE",
+    num_enti: d3.sum(pa, r => r.num_enti),
+    tot_scelte: d3.sum(pa, r => r.tot_scelte),
+    importo_totale: d3.sum(pa, r => r.importo_totale),
+  }] : []),
+];
+
+const lookup = buildMapLookup(perRegioneUnificata, regioniGeo, "regione", "importo_totale");
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Enti beneficiari</h3>
+    <span class="big">${num(data.num_enti)}</span>
+  </div>
+  <div class="card">
+    <h3>Importo totale</h3>
+    <span class="big">${euro(data.importo_totale)}</span>
+  </div>
+  <div class="card">
+    <h3>Scelte dei contribuenti</h3>
+    <span class="big">${num(data.tot_scelte)}</span>
+  </div>
+</div>
+
+---
+
+## Quanto riceve ogni regione?
+
+La distribuzione territoriale del 5x1000 è fortemente concentrata: Lombardia e Lazio da sole assorbono oltre la metà delle risorse.
+
+```js
+Plot.plot({
+  title: `Importi 5x1000 per regione — ${data.anno}`,
+  projection: {type: "mercator", domain: regioniGeo},
+  width: 800,
+  height: 600,
+  color: {scheme: "OrRd", legend: true, label: "Importo erogabile (€)", type: "quantile"},
+  marks: [
+    Plot.geo(regioniGeo, {
+      fill: d => lookup.get(normalizzaReg(d.properties.DEN_REG)),
+      stroke: "#888",
+      strokeWidth: 0.25,
+      title: d => `${d.properties.DEN_REG}: ${euro(lookup.get(normalizzaReg(d.properties.DEN_REG)))}`
+    }),
+    Plot.geo(confiniReg, {stroke: "#888", strokeWidth: 0.7}),
+    Plot.tip(regioniGeo, Plot.pointer({
+      channels: {
+        regione: d => d.properties.DEN_REG,
+        importo: d => lookup.get(normalizzaReg(d.properties.DEN_REG))
+      },
+      format: {regione: d => d, importo: d => euro(d)}
+    }))
+  ]
+})
+```
+
+---
+
+## Dove va il 5x1000?
+
+L'81% delle risorse va agli enti del Terzo Settore (ETS e ONLUS). La ricerca sanitaria e scientifica assorbe un altro 16%. Sport, comuni e beni culturali pesano per il restante 3%.
+
+```js
+Plot.plot({
+  title: `5x1000 per categoria — ${data.anno}`,
+  width: 800,
+  height: 350,
+  marginLeft: 200,
+  y: {label: null, tickSize: 0},
+  x: {grid: true, tickFormat: d => euro(d)},
+  color: {scheme: "Set2"},
+  marks: [
+    Plot.barX(per_categoria, {
+      y: "categoria",
+      x: "importo_totale",
+      fill: "categoria",
+      sort: {y: "-x"},
+      tip: {format: {x: d => euro(Number(d))}}
+    }),
+    Plot.text(per_categoria, {
+      y: "categoria",
+      x: "importo_totale",
+      text: d => euro(d.importo_totale) + " — " + num(d.num_enti) + " enti",
+      dx: 8,
+      textAnchor: "start",
+      fill: "var(--theme-foreground-muted)",
+      fontSize: 11
+    }),
+    Plot.ruleX([0])
+  ]
+})
+```
+
+---
+
+## Dettaglio enti
+
+Cerca un ente per nome, oppure filtra per regione.
+
+```js
+const { header, format } = tableFormat({
+  denominazione: "string",
+  regione: "string",
+  sigla_provincia: "string",
+  comune: "string",
+  numero_scelte: "num",
+  importo_totale: "euro"
+});
+```
+
+```js
+const searchQuery = view(Inputs.search(top_enti, {label: "Cerca ente", placeholder: "digita il nome…"}));
+const regioniList = ["Tutte", ...new Set(top_enti.map(d => d.regione).sort())];
+const regioneFilter = view(Inputs.select(regioniList, {label: "Regione"}));
+```
+
+```js
+const tableData = searchQuery
+  .filter(d => regioneFilter === "Tutte" || d.regione === regioneFilter);
+```
+
+```js
+Inputs.table(tableData, {
+  columns: ["denominazione", "regione", "sigla_provincia", "comune", "numero_scelte", "importo_totale"],
+  header,
+  format,
+  rows: 20,
+  width: "100%",
+  sort: "importo_totale",
+  reverse: true
+})
+```
+
+---
+
+## Limiti
+
+- **Copertura**: il dataset copre il solo 2024. Non sono ancora disponibili i dati 2025 nel formato clean.
+- **Dettaglio ente**: la denominazione degli enti può contenere refusi o caratteri anomali (es. "Bambin Ges?" invece di "Bambin Gesù") ereditati dai CSV originali dell'Agenzia delle Entrate.
+- **Categorie multiple**: un ente può appartenere a più categorie contemporaneamente (es. ente ETS che fa anche ricerca scientifica). Nel grafico per categoria ogni ente è conteggiato in tutte le sue categorie.
+
+---
+
+## Risorse
+
+- [Agenzia delle Entrate — 5x1000 (fonte originale)](https://www.agenziaentrate.gov.it/portale/area-tematica-5x1000)
+- [Scarica il parquet pulito](https://storage.googleapis.com/dataciviclab-clean/ade_cinque_per_mille/2024/ade_cinque_per_mille_2024_clean.parquet)
+- [Pipeline](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/ade-cinque-per-mille)

--- a/src/dataset/cinque-per-mille.md
+++ b/src/dataset/cinque-per-mille.md
@@ -175,7 +175,7 @@ Inputs.table(tableData, {
 
 - **Copertura**: il dataset copre il solo 2024. Non sono ancora disponibili i dati 2025 nel formato clean.
 - **Dettaglio ente**: la denominazione degli enti può contenere refusi o caratteri anomali (es. "Bambin Ges?" invece di "Bambin Gesù") ereditati dai CSV originali dell'Agenzia delle Entrate.
-- **Categorie multiple**: un ente può appartenere a più categorie contemporaneamente (es. ente ETS che fa anche ricerca scientifica). Nel grafico per categoria ogni ente è conteggiato in tutte le sue categorie.
+- **Categorie esclusive**: ogni ente è classificato in una singola categoria prevalente. Un ente con più attributi (es. ETS che fa anche ricerca) viene assegnato alla categoria che ne descrive l'attività principale secondo la priorità: ETS/ONLUS → sport → ricerca → comuni → beni culturali → aree protette. Per questo la categoria "Ricerca scientifica" può sembrare sottorappresentata: molti enti di ricerca sono anche ETS e compaiono sotto "ETS / ONLUS".
 
 ---
 

--- a/src/temi/terzo-settore.md
+++ b/src/temi/terzo-settore.md
@@ -1,0 +1,57 @@
+---
+title: Terzo settore
+description: 5x1000, enti non profit, flussi finanziari al terzo settore
+---
+
+# Terzo settore
+
+Enti beneficiari del 5x1000: importi erogabili, numero di scelte e distribuzione per regione e categoria.
+
+```js
+const catalog = await FileAttachment("../data/catalog.json").json();
+const themes = await FileAttachment("../data/themes.json").json();
+const theme = themes.find(t => t.slug === "terzo-settore");
+const datasets = theme.datasets.map(slug => catalog.datasets.find(d => d.url_slug === slug)).filter(Boolean);
+```
+
+```js
+const totDatasets = datasets.length;
+const sources = [...new Set(datasets.map(d => d.source))];
+```
+
+<div class="grid grid-cols-3">
+  <div class="card">
+    <h3>Dataset</h3>
+    <span class="big">${totDatasets}</span>
+  </div>
+  <div class="card">
+    <h3>Fonti</h3>
+    <span class="big">${sources.length}</span>
+  </div>
+  <div class="card">
+    <h3>Stato</h3>
+    <span class="big">In crescita</span>
+  </div>
+</div>
+
+---
+
+## Dataset del tema
+
+```js
+display(html`<div class="card">
+    <h3><a href="/dataset/${datasets[0].url_slug}">${datasets[0].name}</a></h3>
+    <p style="opacity:0.7; font-size:0.9em">${datasets[0].description}</p>
+    <p style="font-size:0.85em">${datasets[0].years} · ${datasets[0].stage === "published" ? "✅ Pubblicato" : "🔬 Incubazione"}</p>
+</div>`)
+```
+
+---
+
+## Esplora per tema
+
+- [Territorio e ambiente](/temi/territorio-ambiente)
+- [Finanza pubblica](/temi/finanza-pubblica)
+- [Sanità](/temi/sanita)
+- [Welfare e lavoro](/temi/welfare-lavoro)
+- [Giustizia](/temi/giustizia)


### PR DESCRIPTION
## Sintesi
Closes #173 
Nuova pagina dataset per il 5x1000 (Agenzia delle Entrate): 90.611 enti, €521,9 milioni distribuiti nel 2024. Mappa coropletica per regione, bar chart per categoria, tabella enti con filtri per nome e regione.

## Contesto collegato

Collegata all'analisi in dataciviclab#365 e alla discussion #363.

## Cosa cambia

- [x] Nuovo dataset — pagina explorer

## Checklist nuovo dataset

- [x] **Data loader**: `src/data/cinque-per-mille.json.py` — usa `safe_connect()` (non `duckdb.connect()`)
- [x] **Pagina**: `src/dataset/cinque-per-mille.md` — usa moduli condivisi (`format-utils.js`, `geo-utils.js`)
- [x] **Tema**: aggiornato `src/data/themes.json.py` con nuovo tema "Terzo settore"
- [x] **Frontmatter**: `title`, `description`, `source`, `source_url`, `period`, `last_modified`, `dataset_slug`
- [x] **Sezione Limiti** obbligatoria
- [ ] **Verifica**: `npm run lint` e `npm test` passano (da verificare in CI)

## Standard check

- [x] **Niente `toLocaleString`** — usare `num()`, `euro()`, `pct()` da `format-utils.js`
- [x] **`tableFormat` e `Inputs.table` in celle separate**
- [x] **Mappe**: usare `buildMapLookup()`
- [x] **Sidebar**: auto-generata da `themes.json.py` — non modificato `observablehq.config.js`
