### PR TITLE
fix: gestione importo NULL e classificazione categorie 5x1000

### DIFF
--- a/src/data/cinque-per-mille.json.py
+++ b/src/data/cinque-per-mille.json.py
@@ -23,7 +23,7 @@ with safe_connect() as con:
         SELECT regione,
                COUNT(*) AS num_enti,
                SUM(numero_scelte) AS tot_scelte,
-               ROUND(SUM(importo_totale_erogabile), 0) AS importo_totale
+               ROUND(SUM(COALESCE(importo_totale_erogabile, 0)), 0) AS importo_totale
         FROM ({parquet_refs})
         WHERE regione IS NOT NULL
         GROUP BY regione
@@ -34,7 +34,13 @@ with safe_connect() as con:
         SELECT
             CASE
                 WHEN flag_ets_onlus = true AND flag_asd = false AND flag_comune = false
-                     THEN 'ETS / ONLUS'
+                     AND flag_ricerca_scientifica = false AND flag_ricerca_sanitaria = false THEN 'ETS / ONLUS'
+                WHEN flag_ets_onlus = true AND flag_asd = false AND flag_comune = false
+                     AND flag_ricerca_scientifica = true AND flag_ricerca_sanitaria = true THEN 'ETS + Ricerca scientifica e sanitaria'
+                WHEN flag_ets_onlus = true AND flag_asd = false AND flag_comune = false
+                     AND flag_ricerca_scientifica = true THEN 'ETS + Ricerca scientifica'
+                WHEN flag_ets_onlus = true AND flag_asd = false AND flag_comune = false
+                     AND flag_ricerca_sanitaria = true THEN 'ETS + Ricerca sanitaria'
                 WHEN flag_asd = true THEN 'Sportive dilettantistiche'
                 WHEN flag_ricerca_scientifica = true AND flag_ricerca_sanitaria = true THEN 'Ricerca scientifica e sanitaria'
                 WHEN flag_ricerca_scientifica = true THEN 'Ricerca scientifica'
@@ -45,7 +51,7 @@ with safe_connect() as con:
                 ELSE 'Altro'
             END AS categoria,
             COUNT(*) AS num_enti,
-            ROUND(SUM(importo_totale_erogabile), 0) AS importo_totale
+            ROUND(SUM(COALESCE(importo_totale_erogabile, 0)), 0) AS importo_totale
         FROM ({parquet_refs})
         GROUP BY categoria
         ORDER BY importo_totale DESC
@@ -54,9 +60,9 @@ with safe_connect() as con:
     top_enti = _query(f"""
         SELECT denominazione, regione, sigla_provincia, comune,
                numero_scelte,
-               ROUND(importo_totale_erogabile, 0) AS importo_totale
+               ROUND(COALESCE(importo_totale_erogabile, 0), 0) AS importo_totale
         FROM ({parquet_refs})
-        ORDER BY importo_totale_erogabile DESC
+        ORDER BY importo_totale_erogabile DESC NULLS LAST
         LIMIT 500
     """)
 

--- a/src/dataset/cinque-per-mille.md
+++ b/src/dataset/cinque-per-mille.md
@@ -10,7 +10,7 @@ dataset_slug: ade_cinque_per_mille
 
 # 5x1000 — Beneficiari e importi per ente
 
-Ogni anno, i contribuenti italiani possono destinare il 5x1000 della propria IRPEF a enti del terzo settore, ricerca scientifica, sanitaria, comuni, associazioni sportive e beni culturali. Nel 2024 oltre **90.000 enti** hanno ricevuto più di **€520 milioni** da 16,7 milioni di scelte. Questa pagina mostra come si distribuiscono: per territorio, per categoria e per singolo ente.
+Ogni anno, i contribuenti italiani possono destinare il 5x1000 della propria IRPEF a enti del terzo settore, ricerca scientifica, sanitaria, comuni, associazioni sportive e beni culturali. Nel 2024 oltre **90.000 enti** hanno ricevuto più di **€520 milioni** da 15,1 milioni di scelte. Questa pagina mostra come si distribuiscono: per territorio, per categoria e per singolo ente.
 
 **Fonte**: [Agenzia delle Entrate](https://www.agenziaentrate.gov.it/portale/area-tematica-5x1000) · **Periodo**: 2024
 
@@ -175,7 +175,7 @@ Inputs.table(tableData, {
 
 - **Copertura**: il dataset copre il solo 2024. Non sono ancora disponibili i dati 2025 nel formato clean.
 - **Dettaglio ente**: la denominazione degli enti può contenere refusi o caratteri anomali (es. "Bambin Ges?" invece di "Bambin Gesù") ereditati dai CSV originali dell'Agenzia delle Entrate.
-- **Categorie esclusive**: ogni ente è classificato in una singola categoria prevalente. Un ente con più attributi (es. ETS che fa anche ricerca) viene assegnato alla categoria che ne descrive l'attività principale secondo la priorità: ETS/ONLUS → sport → ricerca → comuni → beni culturali → aree protette. Per questo la categoria "Ricerca scientifica" può sembrare sottorappresentata: molti enti di ricerca sono anche ETS e compaiono sotto "ETS / ONLUS".
+- **Categorie esclusive**: ogni ente è classificato in una singola categoria prevalente. Un ente con più attributi (es. ETS che fa anche ricerca) viene assegnato alla categoria più specifica: gli ETS con attività di ricerca compaiono come "ETS + Ricerca scientifica", non sotto "ETS / ONLUS".
 
 ---
 

--- a/src/dataset/cinque-per-mille.md
+++ b/src/dataset/cinque-per-mille.md
@@ -96,7 +96,7 @@ Plot.plot({
 
 ## Dove va il 5x1000?
 
-L'81% delle risorse va agli enti del Terzo Settore (ETS e ONLUS). La ricerca sanitaria e scientifica assorbe un altro 16%. Sport, comuni e beni culturali pesano per il restante 3%.
+L'81% delle risorse va agli enti del Terzo Settore (ETS e ONLUS). La ricerca sanitaria e scientifica non ETS assorbe il 12%. Il restante 7% va a sport, comuni, beni culturali e aree protette.
 
 ```js
 Plot.plot({


### PR DESCRIPTION
## Sintesi\n\nCorregge due problemi nel data loader della pagina 5x1000:\n1. **Importo NULL**: 15.008 enti ETS con importo nullo finivano nella fascia >1M per errore (NULL < soglia = false → ELSE). Aggiunto COALESCE e NULLS LAST.\n2. **Classificazione**: gli ETS che fanno anche ricerca scientifica/sanitaria ora hanno categorie dedicate (ETS + Ricerca scientifica e sanitaria, ETS + Ricerca scientifica, ETS + Ricerca sanitaria) invece di essere aggregati in ETS / ONLUS.\n\n## Verifica\n\nLoader testato: produce JSON valido con 90.611 enti.